### PR TITLE
Fix useLockedBody not successfully unlocking the body

### DIFF
--- a/lib/src/useLockedBody/useLockedBody.ts
+++ b/lib/src/useLockedBody/useLockedBody.ts
@@ -41,8 +41,7 @@ function useLockedBody(initialLocked = false): ReturnType {
     if (locked !== initialLocked) {
       setLocked(initialLocked)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialLocked])
+  }, [locked, initialLocked])
 
   return [locked, setLocked]
 }


### PR DESCRIPTION
The `useLockedBody` hook would successfully lock the body, but when calling `setLocked`, the hook would not run again. This is because the hook's `useEffect` was missing a dependency.