### PR TITLE
useElementSize should use useLayoutEffect

### DIFF
--- a/lib/src/useElementSize/useElementSize.ts
+++ b/lib/src/useElementSize/useElementSize.ts
@@ -28,7 +28,7 @@ function useElementSize<T extends HTMLElement = HTMLDivElement>(
   }, [elementRef])
 
   // Initial size on mount
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateSize()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
Many apps need to synchronously grab the element size to avoid a flicker where the element size is still 0. This changes solves the flicker.