### PR TITLE
Fixed edit link

### DIFF
--- a/site/src/templates/post.tsx
+++ b/site/src/templates/post.tsx
@@ -53,7 +53,7 @@ function PostTemplate(props: PostTemplateProps) {
   const { post, hook, demo } = props.data
   const { body, excerpt, frontmatter } = post
   const repoUrl = 'https://github.com/juliencrn/usehooks-ts'
-  const editLink = `${repoUrl}/tree/develop/src/hooks/${post.fields.name}`
+  const editLink = `${repoUrl}/tree/master/lib/src/${post.fields.name}`
 
   return (
     <StyledContainer maxWidth="md">


### PR DESCRIPTION
# Fixed edit link on site

## Bug

I just found this repository through an article what I found on [daily.dev](https://daily.dev) and when I wanted to open a hook's github page from the site (at: `See a way to make this page better? Edit there »`) I got a 404.

## Fix

So after that I took a look at the repository and I found out that the link was pointing at a branch where the folders wasn't available already I looked for the hooks in the master branch. I replaced the editLink's path in the `site/src/templates/post.tsx` and it worked correctly again.

Great library! :)