### PR TITLE
add param to allow 'mouseup' event

### DIFF
--- a/lib/src/useOnClickOutside/useOnClickOutside.ts
+++ b/lib/src/useOnClickOutside/useOnClickOutside.ts
@@ -7,8 +7,9 @@ type Handler = (event: MouseEvent) => void
 function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   handler: Handler,
+  mouseEvent: 'mousedown' | 'mouseup' = 'mousedown'
 ): void {
-  useEventListener('mousedown', event => {
+  useEventListener(mouseEvent, event => {
     const el = ref?.current
 
     // Do nothing if clicking ref's element or descendent elements


### PR DESCRIPTION
In some cases mousedown fires too early. For example, when clicking on a button below a collapsible section using useOnClickOutside the layout shifts causing the buttons onClick event to be missed. Having an option to change the mouse event to mouseup would help ensure both onClick and useOnClickOutside events work.