### PR TITLE
Fix issue with useLocalStorage

### DIFF
--- a/lib/src/useLocalStorage/useLocalStorage.ts
+++ b/lib/src/useLocalStorage/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState, useCallback } from 'react'
 
 // See: https://usehooks-ts.com/react-hook/use-event-listener
 import { useEventListener } from '../useEventListener'
@@ -14,7 +14,7 @@ type SetValue<T> = Dispatch<SetStateAction<T>>
 function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
   // Get from local storage then
   // parse stored json or return initialValue
-  const readValue = (): T => {
+  const readValue = useCallback((): T => {
     // Prevent build error "window is undefined" but keep keep working
     if (typeof window === 'undefined') {
       return initialValue
@@ -27,7 +27,7 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
       console.warn(`Error reading localStorage key “${key}”:`, error)
       return initialValue
     }
-  }
+  }, [initialValue, key]);
 
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
@@ -65,9 +65,9 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleStorageChange = () => {
+  const handleStorageChange = useCallback(() => {
     setStoredValue(readValue())
-  }
+  }, [readValue]);
 
   // this only works for other documents, not the current one
   useEventListener('storage', handleStorageChange)
@@ -85,7 +85,7 @@ export default useLocalStorage
 function parseJSON<T>(value: string | null): T | undefined {
   try {
     return value === 'undefined' ? undefined : JSON.parse(value ?? '')
-  } catch (error) {
+  } catch {
     console.log('parsing error on', { value })
     return undefined
   }

--- a/lib/src/useReadLocalStorage/useReadLocalStorage.ts
+++ b/lib/src/useReadLocalStorage/useReadLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 
 // See: https://usehooks-ts.com/react-hook/use-event-listener
 import { useEventListener } from '../useEventListener'
@@ -8,7 +8,7 @@ type Value<T> = T | null
 function useReadLocalStorage<T>(key: string): Value<T> {
   // Get from local storage then
   // parse stored json or return initialValue
-  const readValue = (): Value<T> => {
+  const readValue = useCallback((): Value<T> => {
     // Prevent build error "window is undefined" but keep keep working
     if (typeof window === 'undefined') {
       return null
@@ -21,7 +21,7 @@ function useReadLocalStorage<T>(key: string): Value<T> {
       console.warn(`Error reading localStorage key “${key}”:`, error)
       return null
     }
-  }
+  }, [key]);
 
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
@@ -33,9 +33,9 @@ function useReadLocalStorage<T>(key: string): Value<T> {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleStorageChange = () => {
+  const handleStorageChange = useCallback(() => {
     setStoredValue(readValue())
-  }
+  }, [readValue]);
 
   // this only works for other documents, not the current one
   useEventListener('storage', handleStorageChange)


### PR DESCRIPTION
I was having an issue with `useLocalStorage` in my project, and this change is solving it.

The problem was that when I had 2 tabs opened, and I changed the localStorage value in one of the tabs, the other tab would not always update correctly.
I tried reproducing this bug in a codesandbox but wasn't able to. It's probably a very specific/complex scenario that has to happen. I am using [SWR](https://swr.vercel.app/) to fetch some data based on values from localStorage & other places, but there are also other details that would be too hard to reproduce in a codesandbox.

Even without managing to reproduce this issue separately, I think my proposed change is harmless and I hope it will be accepted, or maybe even improved. Perhaps you guys can better understand why my change would make a difference.
Also, after testing, I concluded that this is the commit that introduced the issue: https://github.com/juliencrn/usehooks-ts/commit/bc3be93ad6a579272d02887b443ec9ff84560cb6 .
Maybe other hooks have similar issues.

Thanks in advance!