### PR TITLE
apply lastest ref pattern to useEventListener.ts

### DIFF
--- a/lib/src/useEventListener/useEventListener.ts
+++ b/lib/src/useEventListener/useEventListener.ts
@@ -29,7 +29,7 @@ function useEventListener<
   
   useLayoutEffect(() => {
     savedHandler.current = handler
-  });
+  }, [handler]);
 
   useEffect(() => {
     // Define the listening target


### PR DESCRIPTION
With the old implementation, user have to use `useCallback` to store their `handler` if they don't want the event to be removed and re-added every time the component rerender. By saving the `handler` in the `savedHandler` we can remove `handler` in the dependency list of `useEffect`. Therefore user don't have to remember to memoize their function in the first place.