### PR TITLE
feat: make setter from useLocalStorage referentially stable

### DIFF
--- a/lib/src/useLocalStorage/useLocalStorage.test.ts
+++ b/lib/src/useLocalStorage/useLocalStorage.test.ts
@@ -113,4 +113,20 @@ describe('useLocalStorage()', () => {
 
     expect(B.current[0]).toBe('edited')
   })
+
+  test('setValue is referentially stable', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 1))
+
+    // Store a reference to the original setValue
+    const originalCallback = result.current[1]
+
+    // Now invoke a state update, if setValue is not referentially stable then this will cause the originalCallback
+    // reference to not be equal to the new setValue function
+    act(() => {
+      const setState = result.current[1]
+      setState(prev => prev + 1)
+    })
+
+    expect(result.current[1] === originalCallback).toBe(true)
+  })
 })

--- a/lib/src/useLocalStorage/useLocalStorage.ts
+++ b/lib/src/useLocalStorage/useLocalStorage.ts
@@ -3,6 +3,7 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react'
 
@@ -39,34 +40,38 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(readValue)
 
+  const setValueRef = useRef<SetValue<T>>()
+
+  setValueRef.current = value => {
+    // Prevent build error "window is undefined" but keeps working
+    if (typeof window == 'undefined') {
+      console.warn(
+        `Tried setting localStorage key “${key}” even though environment is not a client`,
+      )
+    }
+
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value
+
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(newValue))
+
+      // Save state
+      setStoredValue(newValue)
+
+      // We dispatch a custom event so every useLocalStorage hook are notified
+      window.dispatchEvent(new Event('local-storage'))
+    } catch (error) {
+      console.warn(`Error setting localStorage key “${key}”:`, error)
+    }
+  }
+
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.
   const setValue: SetValue<T> = useCallback(
-    value => {
-      // Prevent build error "window is undefined" but keeps working
-      if (typeof window == 'undefined') {
-        console.warn(
-          `Tried setting localStorage key “${key}” even though environment is not a client`,
-        )
-      }
-
-      try {
-        // Allow value to be a function so we have the same API as useState
-        const newValue = value instanceof Function ? value(storedValue) : value
-
-        // Save to local storage
-        window.localStorage.setItem(key, JSON.stringify(newValue))
-
-        // Save state
-        setStoredValue(newValue)
-
-        // We dispatch a custom event so every useLocalStorage hook are notified
-        window.dispatchEvent(new Event('local-storage'))
-      } catch (error) {
-        console.warn(`Error setting localStorage key “${key}”:`, error)
-      }
-    },
-    [key, storedValue],
+    value => setValueRef.current?.(value),
+    [],
   )
 
   useEffect(() => {


### PR DESCRIPTION
BREAKING CHANGE: as setValue is now referentially stable, it will no longer cause
re-renders or effects with it listed as a depenency to fire