### PR TITLE
feat/add support for useMediaQuery in older versions of Safari

### DIFF
--- a/lib/src/useMediaQuery/useMediaQuery.ts
+++ b/lib/src/useMediaQuery/useMediaQuery.ts
@@ -22,10 +22,18 @@ function useMediaQuery(query: string): boolean {
     handleChange()
 
     // Listen matchMedia
-    matchMedia.addEventListener('change', handleChange)
+    if (matchMedia.addListener) {
+      matchMedia.addListener(handleChange);
+    } else {
+      matchMedia.addEventListener('change', handleChange);
+    }
 
     return () => {
-      matchMedia.removeEventListener('change', handleChange)
+      if (matchMedia.removeListener) {
+        matchMedia.removeListener(handleChange);
+      } else {
+        matchMedia.removeEventListener('change', handleChange);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query])

--- a/site/src/hooks-doc/useMediaQuery/useMediaQuery.mdx
+++ b/site/src/hooks-doc/useMediaQuery/useMediaQuery.mdx
@@ -4,3 +4,7 @@ date: '2021-12-01'
 ---
 
 Easily retrieve media dimensions with this Hook React which also works onResize.
+
+**Note:**
+
+Before Safari 14, `MediaQueryList` is based on `EventTarget` and only supports `addListener`/`removeListener` for media queries. If you don't support these versions you may remove these checks. Read more about this on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener).


### PR DESCRIPTION
Via [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener):

> In older browsers MediaQueryList did not yet inherit from [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), so this method was provided as an alias of [EventTarget.addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener). Use addEventListener() instead of addListener() if it is available in the browsers you need to support.

These browsers (Safari <14) error with `'t.addEventListener' is undefined`, this adds support for those browsers and adds a note about it in docs.