### PR TITLE
Added throttling and visual viewport support to useEventListener hook

### DIFF
--- a/lib/src/useEventListener/useEventListener.test.ts
+++ b/lib/src/useEventListener/useEventListener.test.ts
@@ -117,4 +117,29 @@ describe('useEventListener()', () => {
     expect(clickHandler).toHaveBeenCalledWith(expect.any(MouseEvent))
     expect(keydownHandler).toHaveBeenCalledWith(expect.any(KeyboardEvent))
   })
+
+  it('should throttle the event listener handler by the provided time', async () => {
+    const eventName = 'click'
+    const handler = jest.fn()
+
+    renderHook(() =>
+      useEventListener(eventName, handler, ref, { throttle: 20 }),
+    )
+
+    await new Promise<void>(resolve => {
+      const interval = setInterval(() => {
+        fireEvent.click(ref.current)
+      }, 10)
+
+      const resolver = () => {
+        clearInterval(interval)
+        resolve()
+      }
+      setTimeout(resolver, 100)
+    })
+
+    // Runtime of 100ms with an interval of 10ms = 10 calls
+    // Throttled by 20ms = 5 calls
+    expect(handler).toHaveBeenCalledTimes(5)
+  })
 })

--- a/site/src/hooks-doc/useEventListener/useEventListener.demo.tsx
+++ b/site/src/hooks-doc/useEventListener/useEventListener.demo.tsx
@@ -15,7 +15,7 @@ export default function Component() {
   }
 
   // example with window based event
-  useEventListener('scroll', onScroll)
+  useEventListener('scroll', onScroll, null, { throttle: 500 })
 
   // example with element based event
   useEventListener('click', onClick, buttonRef)

--- a/site/src/hooks-doc/useEventListener/useEventListener.mdx
+++ b/site/src/hooks-doc/useEventListener/useEventListener.mdx
@@ -1,8 +1,16 @@
 ---
 title: useEventListener
-date: '2020-06-28'
+date: '2022-04-12'
 ---
 
-Use EventListener with simplicity by React Hook.
-It takes as parameters a `eventName`, a call-back functions (`handler`) and optionally a reference `element`.
-You can see above two examples using `useRef` and `window` based event.
+Add any EventListener with simplicity using this Hook.
+It takes as parameters an `eventName`, a call-back function (`handler`), optionally a reference `element` and an `options` object to configure settings.
+
+The `options` parameter is optional and can be used to configure the behavior and add some additional features.
+
+- `throttle` (time in milliseconds) can be used to throttle the event listener handler by a specified amount of time.
+  This can be useful to improve performance on resize and scroll events for example.
+- `useVisualViewport` can be set to `true` to use the `visualViewport` instead of the `window` object as an event target.
+  For more information refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/visualViewport).
+
+The two examples down below showcase the Hook using `useRef` and an `window` based event.


### PR DESCRIPTION
Hey 👋 
I really like this repo and wanted to contribute some code 😃 
During development I needed the `useEventListener` Hook but slightly tuned.

In this pull request, i've added optional parameters to throttle the fired handler and to use the Window.visualViewport as the fallback target for the event.

Those changes are fully optional and non-breaking. I think some other users can benefit from this too 💯 
I also added a jest test for the throttling option and updated the documentation.

Greetings from Germany!