### PR TITLE
Fixed useFetch hook bug

### DIFF
--- a/lib/src/useFetch/useFetch.ts
+++ b/lib/src/useFetch/useFetch.ts
@@ -44,6 +44,8 @@ function useFetch<T = unknown>(url?: string, options?: RequestInit): State<T> {
     // Do nothing if the url is not given
     if (!url) return
 
+    cancelRequest.current = false;
+
     const fetchData = async () => {
       dispatch({ type: 'loading' })
 


### PR DESCRIPTION
When I was learning how to write about useFetch, I found that when the url changes, it will become the loaded state and will no longer change.(Data will not change)
This is because when the component is updated, cancelRequest will be set true. And will not be reset to false.I think this is bug.
