### PR TITLE
Reverting useEffectOnce hook change

### DIFF
--- a/lib/src/useEffectOnce/useEffectOnce.ts
+++ b/lib/src/useEffectOnce/useEffectOnce.ts
@@ -1,34 +1,8 @@
-import { EffectCallback, useEffect, useRef } from 'react'
+import { EffectCallback, useEffect } from 'react'
 
 function useEffectOnce(effect: EffectCallback) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const destroyFunc = useRef<void | any>()
-  const calledOnce = useRef(false)
-  const renderAfterCalled = useRef(false)
-
-  if (calledOnce.current) {
-    renderAfterCalled.current = true
-  }
-
-  useEffect(() => {
-    if (calledOnce.current) {
-      return
-    }
-
-    calledOnce.current = true
-    destroyFunc.current = effect()
-
-    return () => {
-      if (!renderAfterCalled.current) {
-        return
-      }
-
-      if (destroyFunc.current) {
-        destroyFunc.current()
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(effect, [])
 }
 
 export default useEffectOnce


### PR DESCRIPTION
The previous change was trying to circumvent checks done in React strict-mode. React strict-mode double mounts components to ensure that they mount and unmount cleanly. Effects should be written in such a way as they cleanup properly.

The code in the previous change also didn't work. The cleanup function is never called, either in strict mode, or in non-strict (i.e. production) mode.