### PR TITLE
useLocalStorage: ignore unrelated 'storage' events (& fix perf issue)

### DIFF
--- a/lib/src/useLocalStorage/useLocalStorage.ts
+++ b/lib/src/useLocalStorage/useLocalStorage.ts
@@ -79,9 +79,15 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleStorageChange = useCallback(() => {
-    setStoredValue(readValue())
-  }, [readValue])
+  const handleStorageChange = useCallback(
+    (event: StorageEvent | CustomEvent) => {
+      if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
+        return
+      }
+      setStoredValue(readValue())
+    },
+    [key, readValue]
+  )
 
   // this only works for other documents, not the current one
   useEventListener('storage', handleStorageChange)

--- a/lib/src/useReadLocalStorage/useReadLocalStorage.ts
+++ b/lib/src/useReadLocalStorage/useReadLocalStorage.ts
@@ -33,9 +33,15 @@ function useReadLocalStorage<T>(key: string): Value<T> {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleStorageChange = useCallback(() => {
-    setStoredValue(readValue())
-  }, [readValue])
+  const handleStorageChange = useCallback(
+    (event: StorageEvent | CustomEvent) => {
+      if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
+        return
+      }
+      setStoredValue(readValue())
+    },
+    [key, readValue]
+  )
 
   // this only works for other documents, not the current one
   useEventListener('storage', handleStorageChange)


### PR DESCRIPTION
Do not call `setStoredValue` for storage events whose `key` does not match current localStorage key (this also fixes some perf problems that can occur because of this - setStoredValue was being called too many times).

@juliencrn 