### PR TITLE
Docs/readme contribute node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ npm run dev:site
 npm run test
 ```
 
+### Tooling
+
+Git hooks with husky will lint the code before commit and run tests before push. So before pushing, running the following command at least once is always needed.
+
+```bash
+# Launch the documentation website
+npm run bootstrap
+
+# before push
+npm run dev:site
+```
+
 ### How is structured a hook ?
 
 The hook itself and its unit tests are in the `/lib/src/` folder. It's the strict

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ cd usehooks-ts
 npm run bootstrap
 ```
 
-### Create a new hook
+### Create or update a new hook
 
 ```bash
-# This command will regenerate all the hook boilerplate
+# This command generates boilerplate for new hooks.
+# Skip if updating an existed hook.
 npm run plop
 
 # Then develop the hook (aka test:watch)
@@ -143,18 +144,6 @@ npm run dev:site
 
 # Before commit: exec types-checking, linters and tests
 npm run test
-```
-
-### Tooling
-
-Git hooks with husky will lint the code before commit and run tests before push. So before pushing, running the following command at least once is always needed.
-
-```bash
-# Launch the documentation website
-npm run bootstrap
-
-# before push
-npm run dev:site
 ```
 
 ### How is structured a hook ?

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you need to make any other substantial changes, then follow the project setup
 This project use npm `Lerna` and `npm@8` to manage the different packages.
 Before starting, make sure you have the good system dependencies:
 
-- `node@^16`
+- `node@16.x`
 - `npm@^8`
 
 **Note**: To easily switch node version, consider Node Version Manager (nvm).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "clean": "lerna run clean && lerna clean -y",
-    "bootstrap": "npm ci && lerna exec npm ci && npm run copy:hooks",
+    "bootstrap": "npm ci && lerna exec npm ci && npm run copy:hooks && npm run build:lib",
     "types-check": "lerna run types-check",
     "lint": "npm-run-all --continue-on-error -p lint:*",
     "lint:code": "eslint '**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
Changing node version from `node@^16` to `node@16.x`, to specify that `node@{17,18}` is not compatible.
Also I could not commit nor push without `--no verify`, so I added another `### Tooling` part in the second commit.