### PR TITLE
fix: support for null values in `useLocalStorage`

### DIFF
--- a/lib/src/useLocalStorage/useLocalStorage.ts
+++ b/lib/src/useLocalStorage/useLocalStorage.ts
@@ -104,7 +104,13 @@ export default useLocalStorage
 // A wrapper for "JSON.parse()"" to support "undefined" value
 function parseJSON<T>(value: string | null): T | undefined {
   try {
-    return value === 'undefined' ? undefined : JSON.parse(value ?? '')
+    if ( value === 'undefined' ) {
+      return undefined;
+    } else if ( value === 'null' ) {
+      return null; 
+    } else {
+      return JSON.parse(value);
+    }
   } catch {
     console.log('parsing error on', { value })
     return undefined


### PR DESCRIPTION
It seems like when support for `undefined` was added in #36, support for `null` was lost. This should add support for both null and undefined.