### PR TITLE
fix(docs): Fix misspelling in `useScreen` and `useWindowSize` docs

### DIFF
--- a/site/src/hooks-doc/useScreen/useScreen.mdx
+++ b/site/src/hooks-doc/useScreen/useScreen.mdx
@@ -3,4 +3,4 @@ title: useScreen
 date: '2020-09-28'
 ---
 
-Easily retrieve `window.screen` object with this Hook React which also works onRezise.
+Easily retrieve `window.screen` object with this Hook React which also works onResize.

--- a/site/src/hooks-doc/useWindowSize/useWindowSize.mdx
+++ b/site/src/hooks-doc/useWindowSize/useWindowSize.mdx
@@ -3,4 +3,4 @@ title: useWindowSize
 date: '2020-06-09'
 ---
 
-Easily retrieve window dimensions with this React Hook which also works onRezise.
+Easily retrieve window dimensions with this React Hook which also works onResize.


### PR DESCRIPTION
Address a little misspelling of `onResize` in the docs for `useScreen` and `useWindowSize` hooks. Just a tiny and humble contribution to this amazing and useful library 😊