### PR TITLE
Update useScript.ts

### DIFF
--- a/lib/src/useScript/useScript.ts
+++ b/lib/src/useScript/useScript.ts
@@ -21,7 +21,6 @@ function getScriptNode(src: string) {
 
 /**
  * Load a script and return its status. If the script is already loaded, it will return it's load status immediately.
- * Modified to have an initial load status.
  */
 export function useScript(src: string): UseScriptStatus {
   const [status, setStatus] = useState<UseScriptStatus>(() => {
@@ -53,9 +52,10 @@ export function useScript(src: string): UseScriptStatus {
         scriptNode.src = src;
         scriptNode.async = true;
         scriptNode.setAttribute('data-status', 'loading');
+
         // Add script to document body
         document.body.appendChild(scriptNode);
-
+        // Set cached status as 'loading'
         cachedScriptStatuses[src] = 'loading';
 
         // Store status in attribute on script

--- a/lib/src/useScript/useScript.ts
+++ b/lib/src/useScript/useScript.ts
@@ -2,9 +2,25 @@ import { useEffect, useState } from 'react';
 
 export type UseScriptStatus = 'loading' | 'ok' | 'error';
 
+// Cached script statuses
+const cachedScriptStatuses: Record<string, UseScriptStatus | undefined> = {};
+
+function getScriptNode(src: string) {
+  const node: HTMLScriptElement | null = document.querySelector(
+    `script[src="${src}"]`,
+  );
+  const status = node?.getAttribute('data-status') as
+    | UseScriptStatus
+    | undefined;
+
+  return {
+    node,
+    status,
+  };
+}
+
 /**
  * Load a script and return its status. If the script is already loaded, it will return it's load status immediately.
- * Source https://usehooks-ts.com/react-hook/use-script
  * Modified to have an initial load status.
  */
 export function useScript(src: string): UseScriptStatus {
@@ -14,68 +30,68 @@ export function useScript(src: string): UseScriptStatus {
       return 'loading';
     }
 
-    // Grab existing script status from attribute and set to state.
-    const script = document.querySelector(`script[src="${src}"]`);
-    const dataStatus = script?.getAttribute('data-status') as
-      | UseScriptStatus
-      | undefined;
-
-    return dataStatus || 'loading';
+    return cachedScriptStatuses[src] ?? 'loading';
   });
 
   useEffect(
     () => {
+      const cachedScriptStatus = cachedScriptStatuses[src];
+      if (cachedScriptStatus) {
+        // If the script is already cached, set its status immediately
+        setStatus(cachedScriptStatus);
+        return;
+      }
+
       // Fetch existing script element by src
       // It may have been added by another instance of this hook
-      let script: HTMLScriptElement | null = document.querySelector(
-        `script[src="${src}"]`,
-      );
+      const script = getScriptNode(src);
+      let scriptNode = script.node;
 
-      if (!script) {
+      if (!scriptNode) {
         // Create script
-        script = document.createElement('script');
-        script.src = src;
-        script.async = true;
-        script.setAttribute('data-status', 'loading');
+        scriptNode = document.createElement('script');
+        scriptNode.src = src;
+        scriptNode.async = true;
+        scriptNode.setAttribute('data-status', 'loading');
         // Add script to document body
-        document.body.appendChild(script);
+        document.body.appendChild(scriptNode);
+
+        cachedScriptStatuses[src] = 'loading';
 
         // Store status in attribute on script
         // This can be read by other instances of this hook
         const setAttributeFromEvent = (event: Event) => {
-          script?.setAttribute(
-            'data-status',
-            event.type === 'load' ? 'ok' : 'error',
-          );
+          const scriptStatus: UseScriptStatus =
+            event.type === 'load' ? 'ok' : 'error';
+
+          scriptNode?.setAttribute('data-status', scriptStatus);
         };
 
-        script.addEventListener('load', setAttributeFromEvent);
-        script.addEventListener('error', setAttributeFromEvent);
+        scriptNode.addEventListener('load', setAttributeFromEvent);
+        scriptNode.addEventListener('error', setAttributeFromEvent);
       } else {
         // Grab existing script status from attribute and set to state.
-        const scriptStatus = script.getAttribute('data-status') as
-          | UseScriptStatus
-          | undefined;
-
-        setStatus(scriptStatus || 'loading');
+        setStatus(script.status ?? cachedScriptStatuses[src] ?? 'loading');
       }
 
       // Script event handler to update status in state
       // Note: Even if the script alok exists we still need to add
       // event handlers to update the state for *this* hook instance.
       const setStateFromEvent = (event: Event) => {
-        setStatus(event.type === 'load' ? 'ok' : 'error');
+        const newStatus = event.type === 'load' ? 'ok' : 'error';
+        setStatus(newStatus);
+        cachedScriptStatuses[src] = newStatus;
       };
 
       // Add event listeners
-      script.addEventListener('load', setStateFromEvent);
-      script.addEventListener('error', setStateFromEvent);
+      scriptNode.addEventListener('load', setStateFromEvent);
+      scriptNode.addEventListener('error', setStateFromEvent);
 
       return () => {
         // Remove event listeners on cleanup
-        if (script) {
-          script.removeEventListener('load', setStateFromEvent);
-          script.removeEventListener('error', setStateFromEvent);
+        if (scriptNode) {
+          scriptNode.removeEventListener('load', setStateFromEvent);
+          scriptNode.removeEventListener('error', setStateFromEvent);
         }
       };
     },

--- a/lib/src/useScript/useScript.ts
+++ b/lib/src/useScript/useScript.ts
@@ -21,6 +21,8 @@ function getScriptNode(src: string) {
 
 /**
  * Load a script and return its status. If the script is already loaded, it will return it's load status immediately.
+ * Source https://usehooks-ts.com/react-hook/use-script
+ * Modified to have an initial load status.
  */
 export function useScript(src: string): UseScriptStatus {
   const [status, setStatus] = useState<UseScriptStatus>(() => {
@@ -35,7 +37,7 @@ export function useScript(src: string): UseScriptStatus {
   useEffect(
     () => {
       const cachedScriptStatus = cachedScriptStatuses[src];
-      if (cachedScriptStatus) {
+      if (cachedScriptStatus === 'ok' || cachedScriptStatus === 'error') {
         // If the script is already cached, set its status immediately
         setStatus(cachedScriptStatus);
         return;

--- a/lib/src/useScript/useScript.ts
+++ b/lib/src/useScript/useScript.ts
@@ -1,70 +1,86 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 
-export type Status = 'idle' | 'loading' | 'ready' | 'error'
-export type ScriptElt = HTMLScriptElement | null
+export type UseScriptStatus = 'loading' | 'ok' | 'error';
 
-function useScript(src: string): Status {
-  const [status, setStatus] = useState<Status>(src ? 'loading' : 'idle')
+/**
+ * Load a script and return its status. If the script is already loaded, it will return it's load status immediately.
+ * Source https://usehooks-ts.com/react-hook/use-script
+ * Modified to have an initial load status.
+ */
+export function useScript(src: string): UseScriptStatus {
+  const [status, setStatus] = useState<UseScriptStatus>(() => {
+    if (typeof window === 'undefined') {
+      // SSR Handling - always return 'loading'
+      return 'loading';
+    }
+
+    // Grab existing script status from attribute and set to state.
+    const script = document.querySelector(`script[src="${src}"]`);
+    const dataStatus = script?.getAttribute('data-status') as
+      | UseScriptStatus
+      | undefined;
+
+    return dataStatus || 'loading';
+  });
 
   useEffect(
     () => {
-      if (!src) {
-        setStatus('idle')
-        return
-      }
-
       // Fetch existing script element by src
       // It may have been added by another instance of this hook
-      let script: ScriptElt = document.querySelector(`script[src="${src}"]`)
+      let script: HTMLScriptElement | null = document.querySelector(
+        `script[src="${src}"]`,
+      );
 
       if (!script) {
         // Create script
-        script = document.createElement('script')
-        script.src = src
-        script.async = true
-        script.setAttribute('data-status', 'loading')
+        script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.setAttribute('data-status', 'loading');
         // Add script to document body
-        document.body.appendChild(script)
+        document.body.appendChild(script);
 
         // Store status in attribute on script
         // This can be read by other instances of this hook
         const setAttributeFromEvent = (event: Event) => {
           script?.setAttribute(
             'data-status',
-            event.type === 'load' ? 'ready' : 'error',
-          )
-        }
+            event.type === 'load' ? 'ok' : 'error',
+          );
+        };
 
-        script.addEventListener('load', setAttributeFromEvent)
-        script.addEventListener('error', setAttributeFromEvent)
+        script.addEventListener('load', setAttributeFromEvent);
+        script.addEventListener('error', setAttributeFromEvent);
       } else {
         // Grab existing script status from attribute and set to state.
-        setStatus(script.getAttribute('data-status') as Status)
+        const scriptStatus = script.getAttribute('data-status') as
+          | UseScriptStatus
+          | undefined;
+
+        setStatus(scriptStatus || 'loading');
       }
 
       // Script event handler to update status in state
-      // Note: Even if the script already exists we still need to add
+      // Note: Even if the script alok exists we still need to add
       // event handlers to update the state for *this* hook instance.
       const setStateFromEvent = (event: Event) => {
-        setStatus(event.type === 'load' ? 'ready' : 'error')
-      }
+        setStatus(event.type === 'load' ? 'ok' : 'error');
+      };
 
       // Add event listeners
-      script.addEventListener('load', setStateFromEvent)
-      script.addEventListener('error', setStateFromEvent)
+      script.addEventListener('load', setStateFromEvent);
+      script.addEventListener('error', setStateFromEvent);
 
-      // Remove event listeners on cleanup
       return () => {
+        // Remove event listeners on cleanup
         if (script) {
-          script.removeEventListener('load', setStateFromEvent)
-          script.removeEventListener('error', setStateFromEvent)
+          script.removeEventListener('load', setStateFromEvent);
+          script.removeEventListener('error', setStateFromEvent);
         }
-      }
+      };
     },
     [src], // Only re-run effect if script src changes
-  )
+  );
 
-  return status
+  return status;
 }
-
-export default useScript


### PR DESCRIPTION
- Make it so we get initial load status on first mount
- Add `cachedScriptStatuses`-record for short-circuting & avoiding DOM-lookup


~Potentially, we could have a global `Record<string, string|undefined>` defined rather than relying on `querySelector` to make it faster.~