### PR TITLE
fix: rename `useBoolean`, `useCounter`, `useLockedBody` and `useSidebar` hooks ReturnType to Output

### DIFF
--- a/src/useBoolean/useBoolean.ts
+++ b/src/useBoolean/useBoolean.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
-interface ReturnType {
+interface UseBooleanOutput {
   value: boolean
   setValue: Dispatch<SetStateAction<boolean>>
   setTrue: () => void
@@ -8,7 +8,7 @@ interface ReturnType {
   toggle: () => void
 }
 
-function useBoolean(defaultValue?: boolean): ReturnType {
+function useBoolean(defaultValue?: boolean): UseBooleanOutput {
   const [value, setValue] = useState(!!defaultValue)
 
   const setTrue = useCallback(() => setValue(true), [])

--- a/src/useCounter/useCounter.ts
+++ b/src/useCounter/useCounter.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useState } from 'react'
 
-interface ReturnType {
+interface UseCounterOutput {
   count: number
   increment: () => void
   decrement: () => void
@@ -8,7 +8,7 @@ interface ReturnType {
   setCount: Dispatch<SetStateAction<number>>
 }
 
-function useCounter(initialValue?: number): ReturnType {
+function useCounter(initialValue?: number): UseCounterOutput {
   const [count, setCount] = useState(initialValue || 0)
 
   const increment = () => setCount(x => x + 1)

--- a/src/useLockedBody/useLockedBody.ts
+++ b/src/useLockedBody/useLockedBody.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 
 import { useIsomorphicLayoutEffect } from '..'
 
-type ReturnType = [boolean, (locked: boolean) => void]
+type UseLockedBodyOutput = [boolean, (locked: boolean) => void]
 
-function useLockedBody(initialLocked = false): ReturnType {
+function useLockedBody(initialLocked = false): UseLockedBodyOutput {
   const [locked, setLocked] = useState(initialLocked)
 
   // Do the side effect before render

--- a/website/src/components/layout/useSidebar.ts
+++ b/website/src/components/layout/useSidebar.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { useMediaQuery, useTheme } from '@mui/material'
 
-type ReturnType = [
+type UseSidebarOutput = [
   boolean,
   {
     openSidebar: () => void
@@ -10,7 +10,7 @@ type ReturnType = [
   },
 ]
 
-function useSidebar(): ReturnType {
+function useSidebar(): UseSidebarOutput {
   const { breakpoints } = useTheme()
   const isMobile = useMediaQuery(breakpoints.down('lg'))
   const [isOpen, setOpen] = useState(false)


### PR DESCRIPTION
Closes #233