### PR TITLE
fix: useEventListener passes options to removeEventListener

### DIFF
--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -74,7 +74,7 @@ function useEventListener<
 
     // Remove event listener on cleanup
     return () => {
-      targetElement.removeEventListener(eventName, listener)
+      targetElement.removeEventListener(eventName, listener, options)
     }
   }, [eventName, element, options])
 }


### PR DESCRIPTION
Options passed to `addEventListener` and `removeEventListener` must match for the listener to be removed. I found this issue when using an event in the capture phase.