### PR TITLE
fix: useSessionStorage hydration mismatch

### DIFF
--- a/src/useSessionStorage/useSessionStorage.ts
+++ b/src/useSessionStorage/useSessionStorage.ts
@@ -35,8 +35,8 @@ function useSessionStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
   }, [initialValue, key])
 
   // State to store our value
-  // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState<T>(readValue)
+  // Pass initial value to support hydration server-client
+  const [storedValue, setStoredValue] = useState<T>(initialValue)
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to sessionStorage.


### PR DESCRIPTION
Initial value for `useState` hook should be identical to the one provided in SSR to prevent hydration mismatch error.