### PR TITLE
Fix useLocalStorage API

### DIFF
--- a/src/useLocalStorage/useLocalStorage.ts
+++ b/src/useLocalStorage/useLocalStorage.ts
@@ -49,17 +49,26 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
     }
 
     try {
-      // Allow value to be a function so we have the same API as useState
-      const newValue = value instanceof Function ? value(storedValue) : value
-
-      // Save to local storage
-      window.localStorage.setItem(key, JSON.stringify(newValue))
-
-      // Save state
-      setStoredValue(newValue)
-
-      // We dispatch a custom event so every useLocalStorage hook are notified
-      window.dispatchEvent(new Event('local-storage'))
+      // Allow value to be a function so we have same API as useState.
+      if (value instanceof Function) {
+        // Save state.
+        setStoredValue((prev) => {
+          // Save to local storage.
+          if (typeof window !== "undefined") {
+            window.localStorage.setItem(key, JSON.stringify(value(prev)));
+          }
+          // Return the value execution with the ...
+          // ... prev value so we have same API as useState.
+          return value(prev);
+        });
+      } else {
+        // Save to local storage.
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(key, JSON.stringify(value));
+        }
+        // Save state.
+        setStoredValue(value);
+      }
     } catch (error) {
       console.warn(`Error setting localStorage key “${key}”:`, error)
     }


### PR DESCRIPTION
The way `useLocalStorare` was built does not reflect useState behavior. 

You guys are passing the `getter` to the `setter` instead of getting the previous value, which does not reflect the useState API. It can produce a lot of bugs since the useState api works async and need to get the previous value on the setter, instead of directly the getter, to work correctly.


You can check out the problem running it here: https://codesandbox.io/s/uselocalstorage-sample-mistake-uxms2b

You can check out the solution working here: https://codesandbox.io/s/uselocalstorage-sample-working-right-4ls3ox?file=/src/App.tsx


Same issue:
https://github.com/uidotdev/usehooks/pull/156