### PR TITLE
useSessionStorage improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ coverage
 
 # Local Netlify folder
 .netlify
+
+# Jetbrains products
+.idea
+
+# asdf package manager
+.tool-versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "usehooks-ts",
-      "version": "2.7.2",
+      "version": "2.9.1",
       "license": "MIT",
       "workspaces": [
         "packages/eslint-config-custom"

--- a/src/useSessionStorage/useSessionStorage.test.ts
+++ b/src/useSessionStorage/useSessionStorage.test.ts
@@ -36,13 +36,17 @@ describe('useSessionStorage()', () => {
   })
 
   test('initial state is in the returned state', () => {
-    const { result } = renderHook(() => useSessionStorage('key', 'value'))
+    const { result } = renderHook(() =>
+      useSessionStorage<string>('key', 'value'),
+    )
 
     expect(result.current[0]).toBe('value')
   })
 
   test('Initial state is a callback function', () => {
-    const { result } = renderHook(() => useSessionStorage('key', () => 'value'))
+    const { result } = renderHook(() =>
+      useSessionStorage<string>('key', () => 'value'),
+    )
 
     expect(result.current[0]).toBe('value')
   })

--- a/src/useSessionStorage/useSessionStorage.test.ts
+++ b/src/useSessionStorage/useSessionStorage.test.ts
@@ -117,6 +117,31 @@ describe('useSessionStorage()', () => {
     expect(B.current[0]).toBe('edited')
   })
 
+  test('[Event] Updating one hook does not update others with a different key', () => {
+    let renderCount = 0
+    const { result: A } = renderHook(() => {
+      renderCount++
+      return useSessionStorage('key1', {})
+    })
+    const { result: B } = renderHook(() => useSessionStorage('key2', 'initial'))
+
+    expect(renderCount).toBe(1)
+
+    act(() => {
+      const setStateA = A.current[1]
+      setStateA({ a: 1 })
+    })
+
+    expect(renderCount).toBe(2)
+
+    act(() => {
+      const setStateB = B.current[1]
+      setStateB('edited')
+    })
+
+    expect(renderCount).toBe(2)
+  })
+
   test('setValue is referentially stable', () => {
     const { result } = renderHook(() => useSessionStorage('count', 1))
 

--- a/src/useSessionStorage/useSessionStorage.test.ts
+++ b/src/useSessionStorage/useSessionStorage.test.ts
@@ -142,6 +142,18 @@ describe('useSessionStorage()', () => {
     expect(renderCount).toBe(2)
   })
 
+  test('for complex values, what you set is exactly what you get', () => {
+    const { result } = renderHook(() => useSessionStorage('count', {}))
+
+    const newValueA = { a: 1 }
+    act(() => {
+      const setState = result.current[1]
+      setState(newValueA)
+    })
+
+    expect(result.current[0]).toBe(newValueA)
+  })
+
   test('setValue is referentially stable', () => {
     const { result } = renderHook(() => useSessionStorage('count', 1))
 

--- a/src/useSessionStorage/useSessionStorage.ts
+++ b/src/useSessionStorage/useSessionStorage.ts
@@ -16,21 +16,26 @@ declare global {
 
 type SetValue<T> = Dispatch<SetStateAction<T>>
 
-function useSessionStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
+function useSessionStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+): [T, SetValue<T>] {
   // Get from session storage then
   // parse stored json or return initialValue
   const readValue = useCallback((): T => {
+    const getInitialValue = () =>
+      initialValue instanceof Function ? initialValue() : initialValue
     // Prevent build error "window is undefined" but keep keep working
     if (typeof window === 'undefined') {
-      return initialValue
+      return getInitialValue()
     }
 
     try {
       const item = window.sessionStorage.getItem(key)
-      return item ? (parseJSON(item) as T) : initialValue
+      return item ? (parseJSON(item) as T) : getInitialValue()
     } catch (error) {
       console.warn(`Error reading sessionStorage key “${key}”:`, error)
-      return initialValue
+      return getInitialValue()
     }
   }, [initialValue, key])
 

--- a/src/useSessionStorage/useSessionStorage.ts
+++ b/src/useSessionStorage/useSessionStorage.ts
@@ -42,6 +42,8 @@ function useSessionStorage<T>(
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(readValue)
+  // create a new empty object to keep track of the identity of the hook
+  const [source] = useState({})
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to sessionStorage.
@@ -65,7 +67,7 @@ function useSessionStorage<T>(
 
       // We dispatch a custom event so every useSessionStorage hook are notified
       const customEvent = new CustomEvent('session-storage', {
-        detail: { key },
+        detail: { key, source },
       })
       window.dispatchEvent(customEvent)
     } catch (error) {
@@ -91,9 +93,11 @@ function useSessionStorage<T>(
   const handleStorageChangeOnSamePage = useCallback(
     (event: CustomEvent) => {
       if (event.detail.key !== key) return
+      // don't reset the value of the hook that emitted the event
+      if (event.detail.source === source) return
       setStoredValue(readValue())
     },
-    [key, readValue],
+    [key, readValue, source],
   )
   // this is a custom event, triggered in writeValueTosessionStorage
   // See: useSessionStorage()


### PR DESCRIPTION
This PR has 3 changes for the `useSessionStorage` hook:

1. It allows an initial value function to be used without provoking TS errors.
2. It eliminates changes to the hook state when another instance of the hook with a different storage key is updated.
3. It ensures that the value set to the hook is referentially equal to the value reported by the hook.

I love the library! Please let me know how I can improve the PR for your approval!