### PR TITLE
Fix user of useScreen not rerendering on screen resize

### DIFF
--- a/src/useScreen/useScreen.mdx
+++ b/src/useScreen/useScreen.mdx
@@ -1,6 +1,6 @@
 ---
 title: useScreen
-date: '2020-09-28'
+date: '2023-01-13'
 ---
 
 Easily retrieve `window.screen` object with this Hook React which also works onResize.

--- a/src/useScreen/useScreen.ts
+++ b/src/useScreen/useScreen.ts
@@ -13,7 +13,9 @@ function useScreen() {
   const [screen, setScreen] = useState<Screen | undefined>(getScreen())
 
   function handleSize() {
-    setScreen(getScreen())
+    const newScreen = getScreen()
+    if (newScreen === undefined) return
+    setScreen({ ...newScreen })
   }
 
   useEventListener('resize', handleSize)


### PR DESCRIPTION
The component that uses the useScreen hook will not rerender in it's current state due to window.screen maintaining it's reference. Thus calling setScreen is not triggering a rerender. Fixed by creating a shallow clone of the new screen object.