### PR TITLE
adds id as option to useScript hook

### DIFF
--- a/src/useScript/useScript.demo.tsx
+++ b/src/useScript/useScript.demo.tsx
@@ -10,6 +10,7 @@ export default function Component() {
   // Load the script asynchronously
   const status = useScript(`https://code.jquery.com/jquery-3.5.1.min.js`, {
     removeOnUnmount: false,
+    id: 'jq'
   })
 
   useEffect(() => {

--- a/src/useScript/useScript.ts
+++ b/src/useScript/useScript.ts
@@ -4,6 +4,7 @@ export type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error'
 export interface UseScriptOptions {
   shouldPreventLoad?: boolean
   removeOnUnmount?: boolean
+  id?: string;
 }
 
 // Cached script statuses
@@ -62,6 +63,9 @@ function useScript(
       scriptNode = document.createElement('script')
       scriptNode.src = src
       scriptNode.async = true
+      if(options?.id) {
+        scriptNode.id = options?.id
+      }
       scriptNode.setAttribute('data-status', 'loading')
       document.body.appendChild(scriptNode)
 


### PR DESCRIPTION
I am currently using useScript to download zendesk script but an id is required to make it work. It's working on the project as I copied the whole hook and added the id but I think it would be a good addiction.

Currently using it as
```
const status = useScript("https://static.zdassets.com/ekr/snippet.js?key=8f60d464-1c48-48a6-8d14-25f47c389e59", {
    id: "ze-snippet"
});
```


In order to get the project running I had to install a bunch of eslint dependencies. Not sure if I am doing something wrong.

I was not able to get the docs running, might be due to some setup missing.