### PR TITLE
refactor(useIsMounted): :art: use useMemo instead of useCallback

### DIFF
--- a/src/useIsMounted/useIsMounted.demo.tsx
+++ b/src/useIsMounted/useIsMounted.demo.tsx
@@ -11,7 +11,7 @@ function Child() {
   // simulate an api call and update state
   useEffect(() => {
     void delay(3000).then(() => {
-      if (isMounted()) setData('OK')
+      if (isMounted) setData('OK')
     })
   }, [isMounted])
 

--- a/src/useIsMounted/useIsMounted.test.ts
+++ b/src/useIsMounted/useIsMounted.test.ts
@@ -8,7 +8,7 @@ describe('useIsMounted()', () => {
       result: { current: isMounted },
     } = renderHook(() => useIsMounted())
 
-    expect(isMounted()).toBe(true)
+    expect(isMounted).toBe(true)
   })
 
   test('should return false when component is unmounted', () => {
@@ -19,6 +19,6 @@ describe('useIsMounted()', () => {
 
     unmount()
 
-    expect(isMounted()).toBe(false)
+    expect(isMounted).toBe(false)
   })
 })

--- a/src/useIsMounted/useIsMounted.ts
+++ b/src/useIsMounted/useIsMounted.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 function useIsMounted() {
   const isMounted = useRef(false)
@@ -11,7 +11,7 @@ function useIsMounted() {
     }
   }, [])
 
-  return useCallback(() => isMounted.current, [])
+  return useMemo(() => isMounted.current, [])
 }
 
 export default useIsMounted


### PR DESCRIPTION
Refactored `useIsMounted` to use `useMemo` instead of `useCallback`. This helps in not calling the `isMounted` as `isMounted()` i.e `()` is not required.

This shortens the code and directly use the value of the hook instead of calling it and then using the value.