### PR TITLE
Delete item from cachedScriptStatuses when script node is deleted

### DIFF
--- a/src/useScript/useScript.ts
+++ b/src/useScript/useScript.ts
@@ -103,6 +103,7 @@ function useScript(
 
       if (scriptNode && options?.removeOnUnmount) {
         scriptNode.remove()
+        delete cachedScriptStatuses[src]
       }
     }
   }, [src, options?.shouldPreventLoad, options?.removeOnUnmount])


### PR DESCRIPTION
Currently, the node is deleted on unmount, but next time the same element mounts the script is not included