### PR TITLE
Fix typo error on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd ..
 npm run test
 ```
 
-### How is structured a hook ?
+### How is a hook structured?
 
 ```bash
 📂 ./src


### PR DESCRIPTION
Change "How is structured a hook ?" to "How a hook is structured"