### PR TITLE
[add hook]  useStateSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/usehooks-ts)
 ![npm](https://img.shields.io/npm/v/usehooks-ts)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-88-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <br />
@@ -63,6 +64,7 @@
 - [`useScript()`](https://usehooks-ts.com/react-hook/use-script)
 - [`useSessionStorage()`](https://usehooks-ts.com/react-hook/use-session-storage)
 - [`useSsr()`](https://usehooks-ts.com/react-hook/use-ssr)
+- [`useStateSync()`](https://usehooks-ts.com/react-hook/use-state-sync)
 - [`useStep()`](https://usehooks-ts.com/react-hook/use-step)
 - [`useTernaryDarkMode()`](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
 - [`useTimeout()`](https://usehooks-ts.com/react-hook/use-timeout)

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,6 @@ export { default as useUpdateEffect } from './useUpdateEffect/useUpdateEffect'
 export * from './useUpdateEffect/useUpdateEffect'
 export { default as useWindowSize } from './useWindowSize/useWindowSize'
 export * from './useWindowSize/useWindowSize'
+
+export { default as useStateSync } from './useStateSync/useStateSync'
+export * from './useStateSync/useStateSync'

--- a/src/useStateSync/useStateSync.demo.tsx
+++ b/src/useStateSync/useStateSync.demo.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import useStateSync from './useStateSync'
+
+export default function Component() {
+  const [counter, setCounter] = useStateSync<number>(0)
+  const [multipliedCounter, setMultipliedCounter] = useState(0)
+
+  function handleIncrese() {
+    setCounter(counter + 1, newValue => {
+      setMultipliedCounter(newValue * 2)
+    })
+  }
+
+  function handleDecrease() {
+    setCounter(counter - 1, newValue => {
+      setMultipliedCounter(newValue * 2)
+    })
+  }
+
+  return (
+    <div>
+      <button onClick={handleIncrese}>Increase count by 1</button>
+      <button onClick={handleDecrease}>Decrease count by 1</button>
+    </div>
+  )
+}

--- a/src/useStateSync/useStateSync.mdx
+++ b/src/useStateSync/useStateSync.mdx
@@ -1,0 +1,18 @@
+---
+title: useStateSync
+date: '2023-05-26'
+---
+
+Simple hook that enhances native `useState` with a callback function.
+
+Example of usage :
+React-query useQuery that we don't want to trigger on mount and relying on a state.
+
+Basically you would:
+
+1. Update the state
+2. trigger useEffect hook with state as dep
+3. trigger useQuery refetch
+
+But what if you want to control when the refetch function is called ( not at each state change )?
+Here's come the useStateSync hook that offer total control on state change callback.

--- a/src/useStateSync/useStateSync.test.ts
+++ b/src/useStateSync/useStateSync.test.ts
@@ -1,0 +1,20 @@
+import { waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react-hooks/dom'
+import useStateSync from './useStateSync'
+
+describe('use state sync()', () => {
+  test('should use state sync be ok', () => {
+    const { result } = renderHook(() => useStateSync(0))
+    const [value, setValue] = result.current
+
+    expect(value).toBe(0)
+    expect(typeof setValue).toBe('function')
+  })
+
+  test('should simply return 1 if called without callback', () => {
+    const { result } = renderHook(() => useStateSync(0))
+    const [value, setValue] = result.current
+
+    setValue(value + 1, newValue => expect(newValue).toBe(1))
+  })
+})

--- a/src/useStateSync/useStateSync.ts
+++ b/src/useStateSync/useStateSync.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import useUpdateEffect from '../useUpdateEffect/useUpdateEffect'
+
+type Cb = (...args: any[]) => any
+type SetValueFn<T> = (newStateValue: T, cb?: Cb) => void
+
+function useStateSync<T>(initialValue: T): [T, SetValueFn<T>] {
+  const [stateValue, setStateValue] = useState<T>(initialValue)
+  let callback: Cb | undefined
+
+  const setValue = (newStateValue: T, cb?: Cb) => {
+    if (cb) {
+      callback = cb
+    }
+    setStateValue(() => {
+      return newStateValue
+    })
+  }
+
+  useUpdateEffect(() => {
+    if (callback) {
+      callback(stateValue)
+    }
+  }, [stateValue])
+
+  return [stateValue, setValue]
+}
+
+export default useStateSync

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -56,8 +56,7 @@
       }
     },
     "..": {
-      "name": "usehooks-ts",
-      "version": "2.7.1",
+      "version": "2.9.1",
       "license": "MIT",
       "workspaces": [
         "packages/eslint-config-custom"


### PR DESCRIPTION
Simple hook that enhances native useState with a callback function, like setState when we used to use react with classes.

Example of usage : React-query useQuery that we don't want to trigger on mount and relying on a state.

Basically you would:

Update the state
trigger useEffect hook with state as dep
trigger useQuery refetch
But what i you want to control when the refetch function is called ( not at each state change )? Here's come the useStateSync hook :)