### PR TITLE
chore: add export on usebooleanoutput interface

### DIFF
--- a/packages/usehooks-ts/src/useBoolean/useBoolean.ts
+++ b/packages/usehooks-ts/src/useBoolean/useBoolean.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
-interface UseBooleanOutput {
+export interface UseBooleanOutput {
   value: boolean
   setValue: Dispatch<SetStateAction<boolean>>
   setTrue: () => void


### PR DESCRIPTION
Add export on usebooleanoutput interface so that it can be used globally.