### PR TITLE
fix(Docs): external link to appear

### DIFF
--- a/apps/www/src/components/remote-mdx.tsx
+++ b/apps/www/src/components/remote-mdx.tsx
@@ -58,13 +58,15 @@ export const SmartLink = ({
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a
       className={classes}
       target="_blank"
       rel="noopener noreferrer"
+      href={href}
       {...props}
-    />
+    >
+      {children}
+    </a>
   )
 }
 


### PR DESCRIPTION
As a new official document was created in this PR https://github.com/juliencrn/usehooks-ts/pull/333, the element of moving to an external link in the document disappeared.

Check ➡ [use-intersection-observer](https://usehooks-ts.com/react-hook/use-intersection-observer)

## AS-IS
<img width='600' src='https://github.com/juliencrn/usehooks-ts/assets/33178048/8349a9bb-3db4-42c6-ba63-561b20b1903a' />

## TO-BE
<img width='600' src='https://github.com/juliencrn/usehooks-ts/assets/33178048/06552c6d-e911-4fbe-9277-22b8e8c46b3d' />

In addition, there was an issue where the element going to the external link was not visible on other custom hook document pages, so it was corrected.