### PR TITLE
add useDetectChanges hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-        
+
       - name: Setup Pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/packages/usehooks-ts/src/index.ts
+++ b/packages/usehooks-ts/src/index.ts
@@ -35,3 +35,5 @@ export * from './useTimeout/useTimeout'
 export * from './useToggle/useToggle'
 export * from './useUpdateEffect/useUpdateEffect'
 export * from './useWindowSize/useWindowSize'
+
+export * from './useDetectChanges/useDetectChanges'

--- a/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.demo.tsx
+++ b/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.demo.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable react/display-name */
+import React from 'react'
+
+import { useDetectChanges } from '..'
+
+interface MyComponentProps {
+  prop1: string
+  prop2: string
+}
+
+const SlowComponent = React.memo((props: MyComponentProps) => {
+  const changedProps = useDetectChanges(props)
+
+  // prevRender: props = {prop1: value1, prop2: value2}
+  // currentRender: props = {prop1: newValue1, prop2: value2}
+  // only the prop1 has changed
+  console.log('Who causes the re-render of my pure component?', changedProps) // {prop1: [value1, newValue1]}
+
+  // ...
+
+  return <div>{/* ... */}</div>
+})
+
+export default SlowComponent

--- a/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.md
+++ b/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.md
@@ -1,0 +1,10 @@
+This React hook helps to detect which values have changed during each re-render. This is especially useful when you have a pure component (a component that uses `React.memo()`) and don't know which prop is causing it to re-render, particularly when the prop is a reference type like a function or object.
+
+The hook returns an object containing any changes to the props:
+
+```js
+{
+  prop1: [prevValue, currentValue],
+  prop2: [prevValue, currentValue]
+}
+```

--- a/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.test.ts
+++ b/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useDetectChanges } from './useDetectChanges'
+
+describe('useDetectChanges', () => {
+  test('should return an empty object when initialProps is an empty object', () => {
+    const { result } = renderHook(() => useDetectChanges({}))
+
+    expect(result.current).toEqual({})
+  })
+
+  test('should detect changes in values between renders', () => {
+    const foo = () => {
+      console.log('Nothing')
+    }
+    const prop5 = {
+      nestedProp: 'nestedValue',
+    }
+    const prop6 = [1, 2, 3]
+
+    const initialProps = {
+      prop1: 'value1',
+      prop2: 123,
+      prop3: true,
+      prop4: foo,
+      prop5,
+      prop6,
+    }
+
+    const { result, rerender } = renderHook(props => useDetectChanges(props), {
+      initialProps,
+    })
+
+    // First render
+    expect(result.current).toEqual({})
+
+    // Rerender without changes
+    rerender(initialProps)
+    expect(result.current).toEqual({})
+
+    // Rerender with updated values
+    rerender({
+      prop1: 'value2',
+      prop2: 456,
+      prop3: false,
+      prop4: foo,
+      prop5,
+      prop6,
+    })
+
+    expect(result.current).toEqual({
+      prop1: ['value1', 'value2'],
+      prop2: [123, 456],
+      prop3: [true, false],
+    })
+
+    // update the reference types
+    const newFoo = () => {
+      console.log('Nothing')
+    }
+    const newProp5 = {
+      nestedProp: 'nestedValue',
+    }
+    const newProp6 = [1, 2, 3]
+
+    rerender({
+      prop1: 'value2',
+      prop2: 456,
+      prop3: true,
+      prop4: newFoo,
+      prop5: newProp5,
+      prop6: newProp6,
+    })
+
+    expect(result.current).toEqual({
+      prop3: [false, true],
+      prop4: [foo, newFoo],
+      prop5: [prop5, newProp5],
+      prop6: [prop6, newProp6],
+    })
+  })
+})

--- a/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.ts
+++ b/packages/usehooks-ts/src/useDetectChanges/useDetectChanges.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react'
+
+type UseDetectChangesOutput<T> = {
+  [K in keyof T]: [T[K], T[K]]
+}
+
+export function useDetectChanges<T extends Record<string, any>>(
+  values: T,
+): UseDetectChangesOutput<T> {
+  const prevValues = useRef(values)
+
+  useEffect(() => {
+    prevValues.current = values
+  })
+
+  return (Object.entries(prevValues.current) as [keyof T, T[keyof T]][]).reduce(
+    (acc, [key, value]) => {
+      if (value !== values[key]) {
+        acc[key] = [value, values[key]]
+      }
+      return acc
+    },
+    {} as UseDetectChangesOutput<T>,
+  )
+}


### PR DESCRIPTION
In one of my projects, I had a slow and heavy component that used `React.memo()`, but it still re-rendered when its parent component re-rendered. I wanted to find out which prop was causing my pure component to re-render, so I used this logic. I thought it might be a good idea to extract it into a custom hook and add it to the `usehooks-ts` package.

I followed the instructions for contributing, and the files were generated (I think). The tests passed, but in the last step, when I executed `pnpm build`, it gave me this error at the end:

![Screenshot 2023-07-11 142545](https://github.com/juliencrn/usehooks-ts/assets/62181905/0131d60a-b415-4a2c-968c-121a314a30d7)

However, I committed my changes and pushed them. Excited to contribute to the `usehooks-ts` project and I hope that my custom hook will be a useful addition to the package. Thank you for considering my pull request.
