### PR TITLE
Fix `useIsClient()` refrence invisible in useSsr.md

### DIFF
--- a/packages/usehooks-ts/src/useSsr/useSsr.md
+++ b/packages/usehooks-ts/src/useSsr/useSsr.md
@@ -5,4 +5,8 @@ Quickly know where your code will be executed;
 
 This hook doesn't cause an extra render, it just returns the value directly, at the mount time, and it didn't re-trigger if the value changes.
 
-Otherwise, If you want to be notified when the value changes to react to it, you can use [`useIsClient()`]() instead.
+Otherwise, If you want to be notified when the value changes to react to it, you can use `useIsClient()` instead.
+
+Related hooks:
+
+- [`useIsClient()`](/react-hook/use-is-client)


### PR DESCRIPTION
+added `useIsClient()` to `Related hooks` like it is in [use-session-storage](https://usehooks-ts.com/react-hook/use-session-storage)

Find problem after: [use-ssr()](https://usehooks-ts.com/react-hook/use-ssr#:~:text=Otherwise%2C%20If%20you%20want%20to%20be%20notified%20when%20the%20value%20changes%20to%20react%20to%20it%2C%20you%20can%20use)