### PR TITLE
feat: create useCloseAlert hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-        
+
       - name: Setup Pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/packages/usehooks-ts/src/index.ts
+++ b/packages/usehooks-ts/src/index.ts
@@ -35,3 +35,5 @@ export * from './useTimeout/useTimeout'
 export * from './useToggle/useToggle'
 export * from './useUpdateEffect/useUpdateEffect'
 export * from './useWindowSize/useWindowSize'
+
+export * from './useCloseAlert/useCloseAlert'

--- a/packages/usehooks-ts/src/index.ts
+++ b/packages/usehooks-ts/src/index.ts
@@ -1,5 +1,6 @@
 export * from './useBoolean/useBoolean'
 export * from './useClickAnyWhere/useClickAnyWhere'
+export * from './useCloseAlert/useCloseAlert'
 export * from './useCopyToClipboard/useCopyToClipboard'
 export * from './useCountdown/useCountdown'
 export * from './useCounter/useCounter'
@@ -35,5 +36,3 @@ export * from './useTimeout/useTimeout'
 export * from './useToggle/useToggle'
 export * from './useUpdateEffect/useUpdateEffect'
 export * from './useWindowSize/useWindowSize'
-
-export * from './useCloseAlert/useCloseAlert'

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.demo.tsx
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.demo.tsx
@@ -1,0 +1,10 @@
+import { useCloseAlert } from '..'
+
+export default function Component() {
+  const setCanClose = useCloseAlert()
+
+  return <div>
+    <button onClick={() => setCanClose(false)}>Alert when trying to close window</button>
+    <button onClick={() => setCanClose(true)}>Allow user to close page immediately</button>
+  </div>
+}

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.demo.tsx
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.demo.tsx
@@ -3,8 +3,14 @@ import { useCloseAlert } from '..'
 export default function Component() {
   const setCanClose = useCloseAlert()
 
-  return <div>
-    <button onClick={() => setCanClose(false)}>Alert when trying to close window</button>
-    <button onClick={() => setCanClose(true)}>Allow user to close page immediately</button>
-  </div>
+  return (
+    <div>
+      <button onClick={() => setCanClose(false)}>
+        Alert when trying to close window
+      </button>
+      <button onClick={() => setCanClose(true)}>
+        Allow user to close page immediately
+      </button>
+    </div>
+  )
 }

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.md
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.md
@@ -1,0 +1,7 @@
+This React Hook allows you to show an alert before the user closes, giving you a few seconds of time to save any modified changes by calling the necessary API.
+
+Whenever your app will be busy sending API calls, simply set `setCanClose(false)` which will show an alert to the user before closing like this 👇
+
+![Example of useCloseAlert() React Hook](https://github.com/vsnthdev/vsnthdev/assets/24322511/67b80685-10bb-44f2-89d5-689f842e901b "Example of useCloseAlert() React Hook")
+
+Once you app is done saving data or calling API, you can allow the user again to close the app immediately by setting `setCanClose(true)` which will disable the alert before closing.

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.test.ts
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks/dom'
+
 import { useCloseAlert } from './useCloseAlert'
 
 describe('use close alert()', () => {
@@ -16,7 +17,10 @@ describe('use close alert()', () => {
     })
 
     // if onbeforeunload wasn't attached the above test would fail
-    expect(window.onbeforeunload && window.onbeforeunload({} as any)).toBeUndefined()
+    expect(
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      window.onbeforeunload && window.onbeforeunload({} as any),
+    ).toBeUndefined()
   })
 
   test('should use close alert warn before closing window', () => {
@@ -27,6 +31,9 @@ describe('use close alert()', () => {
     })
 
     // if onbeforeunload wasn't attached the above test would fail
-    expect(window.onbeforeunload && window.onbeforeunload({} as any)).toBe('Changes you made may not be saved.')
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    expect(window.onbeforeunload && window.onbeforeunload({} as any)).toBe(
+      'Changes you made may not be saved.',
+    )
   })
 })

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.test.ts
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.test.ts
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom'
+import { useCloseAlert } from './useCloseAlert'
+
+describe('use close alert()', () => {
+  test('should use close alert be ok', () => {
+    renderHook(() => useCloseAlert())
+
+    expect(typeof window.onbeforeunload).toBe('function')
+  })
+
+  test('should use close alert allow closing window', () => {
+    const { result } = renderHook(() => useCloseAlert())
+
+    act(() => {
+      result.current(true)
+    })
+
+    // if onbeforeunload wasn't attached the above test would fail
+    expect(window.onbeforeunload && window.onbeforeunload({} as any)).toBeUndefined()
+  })
+
+  test('should use close alert warn before closing window', () => {
+    const { result } = renderHook(() => useCloseAlert())
+
+    act(() => {
+      result.current(false)
+    })
+
+    // if onbeforeunload wasn't attached the above test would fail
+    expect(window.onbeforeunload && window.onbeforeunload({} as any)).toBe('Changes you made may not be saved.')
+  })
+})

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.ts
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.ts
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
 export function useCloseAlert() {
   const [canClose, setCanClose] = useState(true)
 
   useEffect(() => {
     if (canClose) {
-      window.onbeforeunload = () => { }
+      // eslint-disable-next-line  @typescript-eslint/no-empty-function
+      window.onbeforeunload = () => {}
     } else {
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
       window.onbeforeunload = (e: any) => {
         // just in case
         if (canClose) return

--- a/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.ts
+++ b/packages/usehooks-ts/src/useCloseAlert/useCloseAlert.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export function useCloseAlert() {
+  const [canClose, setCanClose] = useState(true)
+
+  useEffect(() => {
+    if (canClose) {
+      window.onbeforeunload = () => { }
+    } else {
+      window.onbeforeunload = (e: any) => {
+        // just in case
+        if (canClose) return
+
+        e.returnValue = 'Changes you made may not be saved.'
+        return 'Changes you made may not be saved.'
+      }
+    }
+  }, [canClose])
+
+  return setCanClose
+}


### PR DESCRIPTION
This PR adds a new hook called `useCloseAlert()` that will prevent the page from closing for a few seconds, when the app is sending API calls, or being busy saving user's changes.

It is useful in preventing accidentally immediate closing of apps that are in the process of saving something.

Popular websites like Gmail, Spotify, Twitter and Notion use this technique as well.

Thank you 😀