### PR TITLE
feat: Create useTextInput hook

### DIFF
--- a/packages/usehooks-ts/src/useTextInput/useTextInput.demo.tsx
+++ b/packages/usehooks-ts/src/useTextInput/useTextInput.demo.tsx
@@ -1,0 +1,31 @@
+import { ChangeEvent } from 'react'
+
+import useTextInput from './useTextInput'
+
+export default function Component() {
+  const { value, error, onChange } = useTextInput({
+    validators: [validateEmail],
+  })
+
+  return (
+    <>
+      <input
+        placeholder="email"
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          onChange(e.target.value.trim())
+        }
+      />
+      <p>{error}</p>
+    </>
+  )
+}
+
+function validateEmail(email: string) {
+  const emailRegex = new RegExp(
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  )
+  if (!emailRegex.test(email)) {
+    throw Error('Please enter a valid email')
+  }
+}

--- a/packages/usehooks-ts/src/useTextInput/useTextInput.md
+++ b/packages/usehooks-ts/src/useTextInput/useTextInput.md
@@ -1,0 +1,3 @@
+`useTextInput` is a simple hook that manages a text input's state and its error (optional).
+
+It optionally receives an object with `initialValue` and `validators`. `validators` is an array of validator functions that throw an error if `value` does not pass the validation. If a validator function throws an error, the `value` state persists but the `error` state will be updated accordingly.

--- a/packages/usehooks-ts/src/useTextInput/useTextInput.test.ts
+++ b/packages/usehooks-ts/src/useTextInput/useTextInput.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom'
+
+import useTextInput from './useTextInput'
+
+describe('useTextInput()', () => {
+  it('should successfully change the value', () => {
+    const { result } = renderHook(() => useTextInput())
+    const { onChange } = result.current
+    act(() => {
+      onChange('hello')
+    })
+    expect(result.current.value).toBe('hello')
+    expect(result.current.error).toBe('')
+  })
+
+  it('should update error if the validator throws an error', () => {
+    const { result } = renderHook(() =>
+      useTextInput({ validators: [validateEmail] }),
+    )
+    const { onChange } = result.current
+    act(() => {
+      onChange('hello')
+    })
+    expect(result.current.value).toBe('hello')
+    expect(result.current.error).toBe('Please enter a valid email')
+  })
+
+  it("should update the error to be the first validator's error if multiple validators throw errors", () => {
+    const { result } = renderHook(() =>
+      useTextInput({ validators: [validateEmail, validatePassword] }),
+    )
+    const { onChange } = result.current
+    act(() => {
+      onChange('hello')
+    })
+    expect(result.current.error).toBe('Please enter a valid email')
+  })
+})
+
+function validateEmail(email: string) {
+  const emailRegex = new RegExp(
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  )
+  if (!emailRegex.test(email)) {
+    throw Error('Please enter a valid email')
+  }
+}
+
+function validatePassword(password: string) {
+  const passwordRegex = new RegExp(
+    /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,16}$/,
+  )
+  if (!passwordRegex.test(password)) {
+    throw Error(
+      'Passwords must be between 8-16 characters and must include at least one alphabet, number, and special character each',
+    )
+  }
+}

--- a/packages/usehooks-ts/src/useTextInput/useTextInput.ts
+++ b/packages/usehooks-ts/src/useTextInput/useTextInput.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+type Props = {
+  initialValue?: string
+  validators?: Array<(value: string) => void>
+}
+
+export default function useTextInput(options?: Props) {
+  const { initialValue = '', validators } = options || {}
+
+  const [value, setValue] = useState(initialValue)
+  const [error, setError] = useState('')
+
+  const onChange = (newVal: string) => {
+    if (!validators) {
+      setValue(newVal)
+      return
+    }
+
+    // Reverse the order of validators to show the first occurring error.
+    validators.reverse().forEach(validator => {
+      try {
+        validator(newVal)
+        setError('')
+      } catch (error) {
+        setError((error as Error).message)
+        return
+      }
+    })
+
+    setValue(newVal)
+  }
+
+  useEffect(() => {
+    onChange(initialValue)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return {
+    value,
+    error,
+    isError: error !== '',
+    onChange,
+  }
+}


### PR DESCRIPTION
This PR adds a `useTextInput` hook that that manages a text input's state and its error (optional).
