### PR TITLE
Feature: Add useEffectTill

### DIFF
--- a/packages/usehooks-ts/src/useEffectTill/useEffectTill.demo.tsx
+++ b/packages/usehooks-ts/src/useEffectTill/useEffectTill.demo.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+import { useEffectTill } from './useEffectTill'
+
+export default function Component() {
+  const [data, setData] = useState<number>(0)
+  useEffect(() => {
+    console.log('Normal useEffect', { data })
+  }, [data])
+
+  useEffectTill(
+    done => {
+      if (data === 0) {
+        console.log('Triggered only once, when data is 0', { data })
+        done()
+      }
+    },
+    [data],
+  )
+
+  return (
+    <div>
+      <p>Open your console</p>
+      <button onClick={() => setData(Date.now())}>Update data</button>
+    </div>
+  )
+}

--- a/packages/usehooks-ts/src/useEffectTill/useEffectTill.md
+++ b/packages/usehooks-ts/src/useEffectTill/useEffectTill.md
@@ -1,0 +1,8 @@
+The `useEffectTill` is a custom hook that runs an effect only until it is done and cleans up after it.
+
+See also:
+
+- [`useEffectOnce()`](/react-hook/use-effect-once): Run an effect only one time, at the mounting time
+- [`useUpdateEffect()`](/react-hook/use-update-effect): Inverse of `useEffectOne()`
+- [`useIsFirstRender()`](/react-hook/use-is-first-render): Return a `boolean`
+- [`useIsMounted()`](/react-hook/use-is-mounted): Callback function to avoid Promise execution after component un-mount

--- a/packages/usehooks-ts/src/useEffectTill/useEffectTill.test.ts
+++ b/packages/usehooks-ts/src/useEffectTill/useEffectTill.test.ts
@@ -1,0 +1,47 @@
+// useEffectTill.test.js
+
+import { renderHook } from '@testing-library/react-hooks/dom'
+
+import { useEffectTill } from './useEffectTill'
+
+describe('useEffectTill', () => {
+  it('should run effect on mount', () => {
+    const effect = jest.fn()
+    renderHook(() => useEffectTill(effect, []))
+    expect(effect).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not re-run effect on updates', () => {
+    const effect = jest.fn()
+    const { rerender } = renderHook(() => useEffectTill(effect, []))
+    rerender()
+    expect(effect).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle empty deps array', () => {
+    const effect = jest.fn()
+    renderHook(() => useEffectTill(effect))
+    expect(effect).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle returned cleanup function', () => {
+    const cleanup = jest.fn()
+    const effect = jest.fn(() => cleanup)
+    const { rerender } = renderHook(() => useEffectTill(effect))
+    rerender()
+    expect(cleanup).toHaveBeenCalled() // Assert cleanup called
+  })
+
+  it('should not run the effect after being done', () => {
+    const cleanup = jest.fn()
+    const effect = jest.fn(done => {
+      done()
+      return () => cleanup()
+    })
+    const { rerender } = renderHook(() => useEffectTill(effect))
+    rerender()
+    expect(effect).toHaveBeenCalledTimes(1)
+    rerender()
+    expect(effect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/usehooks-ts/src/useEffectTill/useEffectTill.ts
+++ b/packages/usehooks-ts/src/useEffectTill/useEffectTill.ts
@@ -1,0 +1,72 @@
+import { DependencyList, useEffect, useRef } from 'react'
+
+/**
+ * This is the type of callback that is passed to useEffectTill.
+ */
+export type EffectTillDone = () => void
+/**
+ * This is the type of function that is returned from `EffectTillCallback`.
+ */
+export type EffectTillDestructor = () => void
+/**
+ * Type definition for the callback function used in useEffectTill.
+ * @param done - The `done` parameter is a callback function that must be called when the effect is done.
+ * @returns The destructor function to clean up the effect.
+ */
+export type EffectTillCallback = (
+  done: EffectTillDone,
+) => void | EffectTillDestructor
+
+/**
+ * The `useEffectTill` function is a custom hook that runs an effect only until it is done and cleans
+ * up after it.
+ * @param effect - The `effect` parameter is a callback function that will be
+ * executed once when the component mounts. It can optionally return a cleanup function that will be
+ * executed when the component unmounts.
+ * @param deps - The `deps` parameter is an optional array of dependencies. It is
+ * similar to the dependencies array used in the regular `useEffect` hook. If provided, the effect will
+ * only be re-run if any of the dependencies in the array have changed since the last render.
+ * @example
+ * ```ts
+ * useEffectTill((done) =>  {
+ *  if (data) {
+ *   // Do something.
+ *      done();
+ *   }
+ * }, [data]);
+ * ```
+ */
+export const useEffectTill = (
+  effect: EffectTillCallback,
+  deps?: DependencyList,
+) => {
+  /**
+   * This is a ref that is used to track if the effect has already run.
+   * @internal
+   */
+  const hasRun = useRef(false)
+  /**
+   * This is a callback that is called when the effect has been completed.
+   * @internal
+   */
+  const handleComplete = () => {
+    hasRun.current = true
+  }
+
+  useEffect(() => {
+    // 1. Create a ref to track the effect's destructor
+    let destructor: EffectTillDestructor = () => undefined
+
+    // 2. If the effect hasn't run yet, run it
+    if (!hasRun.current) {
+      // 3. Run the effect, and store the destructor
+      const result = effect(handleComplete)
+      if (typeof result === 'function') {
+        destructor = result
+      }
+    }
+    // 4. Return the destructor function so it can be cleaned up.
+    return destructor
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}


### PR DESCRIPTION
## PR Description

### Summary

This PR introduces a custom React hook, `useEffectTill`, designed to run an effect only until it is marked as done, handling cleanup afterward. The hook enhances the standard `useEffect` by allowing for precise control over when the effect should run and when it should be cleaned up.

### Changes Made

- Added TypeScript type definitions for the callback functions used in the hook.
- Implemented the `useEffectTill` hook, including tracking if the effect has already run and handling cleanup.
- Added internal comments to enhance code readability and understanding.

### Usage Example

```ts
useEffectTill((done) => {
  if (data) {
    // Do something.
    done();
  }
}, [data]);
```

### Why

The `useEffectTill` hook fills a gap in the React ecosystem by offering developers a way to execute effects with precise control over their lifecycle. It enhances code readability and reduces potential bugs related to effect cleanup.

### How to Test

1. Apply the `useEffectTill` hook in a React component.
2. Write tests to cover scenarios where the effect should and should not run.
3. Verify that cleanup occurs correctly once the effect is marked as done.

### Additional Notes

- This implementation aligns with best practices in React development.
- The code includes appropriate TypeScript typings for a seamless integration into TypeScript projects.
