### PR TITLE
useReadLocalStorage: localStorage failing to parse when not JSON

### DIFF
--- a/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.ts
+++ b/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.ts
@@ -13,11 +13,30 @@ export function useReadLocalStorage<T>(key: string): Value<T> {
       return null
     }
 
+    let item: string | null = ""
+
     try {
-      const item = window.localStorage.getItem(key)
-      return item ? (JSON.parse(item) as T) : null
-    } catch (error) {
+      item = window.localStorage.getItem(key)
+    }
+    catch (error) {
       console.warn(`Error reading localStorage key “${key}”:`, error)
+      return null
+    }
+
+    // try parse as JSON
+    try {
+      return item ? (JSON.parse(item) as T) : null
+    }
+    catch (error) {
+      console.warn(`Error parsing JSON key “${key}”, item “${item}”:`, error)
+    }
+
+    // try return as T
+    try {
+      return item ? item as T : null
+    }
+    catch (error) {
+      console.warn(`Error returning Generic item at key “${key}”:`, error)
       return null
     }
   }, [key])


### PR DESCRIPTION
I've updated useReadLocalStorage to attempt to return T after failing to parse JSON when localStorage values aren't stored as JSON.

Console output.
![image](https://github.com/juliencrn/usehooks-ts/assets/13162026/af2a8ccb-a7d6-4004-90c1-7a206ca57d24)

Debug, plain string localStorage item.
![image](https://github.com/juliencrn/usehooks-ts/assets/13162026/2d10a938-a090-47f1-8d20-cedd1b29aa9b)

Error handler.
![image](https://github.com/juliencrn/usehooks-ts/assets/13162026/f8344905-0aa2-4524-9d05-6a4a433a267d)


