### PR TITLE
🗑️ Depreciate useSsr (#258)

### DIFF
--- a/.changeset/beige-masks-enjoy.md
+++ b/.changeset/beige-masks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+Depreciated useSsr [#258](https://github.com/juliencrn/usehooks-ts/issues/258)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@
 - [`useScreen()`](https://usehooks-ts.com/react-hook/use-screen)
 - [`useScript()`](https://usehooks-ts.com/react-hook/use-script)
 - [`useSessionStorage()`](https://usehooks-ts.com/react-hook/use-session-storage)
-- [`useSsr()`](https://usehooks-ts.com/react-hook/use-ssr)
 - [`useStep()`](https://usehooks-ts.com/react-hook/use-step)
 - [`useTernaryDarkMode()`](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
 - [`useTimeout()`](https://usehooks-ts.com/react-hook/use-timeout)

--- a/packages/usehooks-ts/README.md
+++ b/packages/usehooks-ts/README.md
@@ -63,7 +63,6 @@
 - [`useScreen()`](https://usehooks-ts.com/react-hook/use-screen)
 - [`useScript()`](https://usehooks-ts.com/react-hook/use-script)
 - [`useSessionStorage()`](https://usehooks-ts.com/react-hook/use-session-storage)
-- [`useSsr()`](https://usehooks-ts.com/react-hook/use-ssr)
 - [`useStep()`](https://usehooks-ts.com/react-hook/use-step)
 - [`useTernaryDarkMode()`](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
 - [`useTimeout()`](https://usehooks-ts.com/react-hook/use-timeout)

--- a/packages/usehooks-ts/src/useSsr/useSsr.demo.tsx
+++ b/packages/usehooks-ts/src/useSsr/useSsr.demo.tsx
@@ -1,7 +1,0 @@
-import { useSsr } from '..'
-
-export default function Component() {
-  const { isBrowser } = useSsr()
-
-  return <p>{isBrowser ? 'Browser' : 'Server'}!</p>
-}

--- a/packages/usehooks-ts/src/useSsr/useSsr.md
+++ b/packages/usehooks-ts/src/useSsr/useSsr.md
@@ -1,8 +1,0 @@
-Quickly know where your code will be executed;
-
-- In the server (Server-Side-Rendering) or
-- In the client, the navigator
-
-This hook doesn't cause an extra render, it just returns the value directly, at the mount time, and it didn't re-trigger if the value changes.
-
-Otherwise, If you want to be notified when the value changes to react to it, you can use [`useIsClient()`]() instead.

--- a/packages/usehooks-ts/src/useSsr/useSsr.ts
+++ b/packages/usehooks-ts/src/useSsr/useSsr.ts
@@ -1,3 +1,4 @@
+/** @deprecated useSsr isn't a valid react hook and will be dropped in the next major release. See #258 */
 export function useSsr() {
   const isDOM =
     typeof window !== 'undefined' &&


### PR DESCRIPTION
As explained in #258, `useSsr` isn't a valid hook and will be removed in the next major release. 