### PR TITLE
🐛 make useLocalStorage and useSessionStorage compliant with useState (fixes #204 with #242 by @valyrie97)

### DIFF
--- a/.changeset/lovely-mayflies-cough.md
+++ b/.changeset/lovely-mayflies-cough.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+make useLocalStorage and useSessionStorage compliant with useState (fixes #204 with #242 by @valyrie97)

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -113,6 +113,20 @@ describe('useLocalStorage()', () => {
     expect(window.localStorage.getItem('count')).toEqual('3')
   })
 
+  test('Update the state with a callback function multiple times per render', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 2))
+
+    act(() => {
+      const setState = result.current[1]
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(5)
+    expect(window.localStorage.getItem('count')).toEqual('5')
+  })
+
   test('[Event] Update one hook updates the others', () => {
     const initialValues: [string, unknown] = ['key', 'initial']
     const { result: A } = renderHook(() => useLocalStorage(...initialValues))

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -55,7 +55,7 @@ export function useLocalStorage<T>(
 
     try {
       // Allow value to be a function so we have the same API as useState
-      const newValue = value instanceof Function ? value(storedValue) : value
+      const newValue = value instanceof Function ? value(readValue()) : value
 
       // Save to local storage
       window.localStorage.setItem(key, JSON.stringify(newValue))

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
@@ -100,6 +100,20 @@ describe('useSessionStorage()', () => {
     expect(window.sessionStorage.getItem('count')).toEqual('3')
   })
 
+  test('Update the state with a callback function multiple times per render', () => {
+    const { result } = renderHook(() => useSessionStorage('count', 2))
+
+    act(() => {
+      const setState = result.current[1]
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(5)
+    expect(window.sessionStorage.getItem('count')).toEqual('5')
+  })
+
   test('[Event] Update one hook updates the others', () => {
     const initialValues: [string, unknown] = ['key', 'initial']
     const { result: A } = renderHook(() => useSessionStorage(...initialValues))

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -55,7 +55,7 @@ export function useSessionStorage<T>(
 
     try {
       // Allow value to be a function so we have the same API as useState
-      const newValue = value instanceof Function ? value(storedValue) : value
+      const newValue = value instanceof Function ? value(readValue()) : value
 
       // Save to session storage
       window.sessionStorage.setItem(key, JSON.stringify(newValue))


### PR DESCRIPTION
🐛 make `useLocalStorage` and `useSessionStorage` compliant with `useState`.

Fixes:
- #204
-  #242 
- #257 

Thanks @valyrie97