### PR TITLE
Feature/add optional serialization to use storage

### DIFF
--- a/.changeset/eighty-experts-hear.md
+++ b/.changeset/eighty-experts-hear.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+Add Date, Set & Map support to use\*Storage (#309 by @AlecsFarias)

--- a/.changeset/young-shirts-share.md
+++ b/.changeset/young-shirts-share.md
@@ -1,0 +1,5 @@
+---
+'usehooks-ts': minor
+---
+
+Add serialization support for use-\*-storage hooks

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
@@ -2,6 +2,8 @@ Persist the state with local storage so that it remains after a page refresh. Th
 This hook is used in the same way as useState except that you must pass the storage key in the 1st parameter.
 If the window object is not present (as in SSR), `useLocalStorage()` will return the default value.
 
+You can also pass an optional third parameter to use a custom serializer/deserializer.
+
 **Side notes:**
 
 - If you really want to create a dark theme switch, see [useDarkMode()](/react-hook/use-dark-mode).

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -159,4 +159,54 @@ describe('useLocalStorage()', () => {
 
     expect(result.current[1] === originalCallback).toBe(true)
   })
+
+  test('should use default JSON.stringify and JSON.parse when serializer/deserializer not provided', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'initialValue'))
+
+    act(() => {
+      result.current[1]('newValue')
+    })
+
+    expect(localStorage.getItem('key')).toBe(JSON.stringify('newValue'))
+  })
+
+  test('should use custom serializer and deserializer when provided', () => {
+    const serializer = (value: string) => value.toUpperCase()
+    const deserializer = (value: string) => value.toLowerCase()
+
+    const { result } = renderHook(() =>
+      useLocalStorage('key', 'initialValue', { serializer, deserializer }),
+    )
+
+    act(() => {
+      result.current[1]('NewValue')
+    })
+
+    expect(localStorage.getItem('key')).toBe('NEWVALUE')
+  })
+
+  test('should handle undefined values with custom deserializer', () => {
+    const serializer = (value: number | undefined) => String(value)
+    const deserializer = (value: string) =>
+      value === 'undefined' ? undefined : Number(value)
+
+    const { result } = renderHook(() =>
+      useLocalStorage<number | undefined>('key', 0, {
+        serializer,
+        deserializer,
+      }),
+    )
+
+    act(() => {
+      result.current[1](undefined)
+    })
+
+    expect(localStorage.getItem('key')).toBe('undefined')
+
+    act(() => {
+      result.current[1](42)
+    })
+
+    expect(localStorage.getItem('key')).toBe('42')
+  })
 })

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -144,6 +144,31 @@ describe('useLocalStorage()', () => {
     expect(C.current[0]).toBe('initial')
   })
 
+  test('[Event] Updating one hook does not update others with a different key', () => {
+    let renderCount = 0
+    const { result: A } = renderHook(() => {
+      renderCount++
+      return useLocalStorage('key1', {})
+    })
+    const { result: B } = renderHook(() => useLocalStorage('key2', 'initial'))
+
+    expect(renderCount).toBe(1)
+
+    act(() => {
+      const setStateA = A.current[1]
+      setStateA({ a: 1 })
+    })
+
+    expect(renderCount).toBe(2)
+
+    act(() => {
+      const setStateB = B.current[1]
+      setStateB('edited')
+    })
+
+    expect(renderCount).toBe(2)
+  })
+
   test('setValue is referentially stable', () => {
     const { result } = renderHook(() => useLocalStorage('count', 1))
 

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -53,6 +53,28 @@ describe('useLocalStorage()', () => {
     expect(result.current[0]).toEqual([1, 2])
   })
 
+  test('Initial state is a Map', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('map', new Map([['a', 1]])),
+    )
+
+    expect(result.current[0]).toEqual(new Map([['a', 1]]))
+  })
+
+  test('Initial state is a Set', () => {
+    const { result } = renderHook(() => useLocalStorage('set', new Set([1, 2])))
+
+    expect(result.current[0]).toEqual(new Set([1, 2]))
+  })
+
+  test('Initial state is a Date', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('date', new Date(2020, 1, 1)),
+    )
+
+    expect(result.current[0]).toEqual(new Date(2020, 1, 1))
+  })
+
   test('Update the state', () => {
     const { result } = renderHook(() => useLocalStorage('key', 'value'))
 

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -36,6 +36,15 @@ export function useLocalStorage<T>(
       if (options.serializer) {
         return options.serializer(value)
       }
+
+      if (value instanceof Map) {
+        return JSON.stringify(Object.fromEntries(value))
+      }
+
+      if (value instanceof Set) {
+        return JSON.stringify(Array.from(value))
+      }
+
       return JSON.stringify(value)
     },
     [options],
@@ -50,9 +59,24 @@ export function useLocalStorage<T>(
       if (value === 'undefined') {
         return undefined as unknown as T
       }
-      return JSON.parse(value)
+
+      const parsed = JSON.parse(value)
+
+      if (initialValue instanceof Set) {
+        return new Set(parsed)
+      }
+
+      if (initialValue instanceof Map) {
+        return new Map(Object.entries(parsed))
+      }
+
+      if (initialValue instanceof Date) {
+        return new Date(parsed)
+      }
+
+      return parsed
     },
-    [options],
+    [options, initialValue],
   )
 
   // Get from local storage then

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -25,7 +25,7 @@ const IS_SERVER = typeof window === 'undefined'
 
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T,
+  initialValue: T | (() => T),
   options: Options<T> = {},
 ): [T, SetValue<T>] {
   // Pass initial value to support hydration server-client
@@ -58,17 +58,20 @@ export function useLocalStorage<T>(
   // Get from local storage then
   // parse stored json or return initialValue
   const readValue = useCallback((): T => {
+    const initialValueToUse =
+      initialValue instanceof Function ? initialValue() : initialValue
+
     // Prevent build error "window is undefined" but keeps working
     if (IS_SERVER) {
-      return initialValue
+      return initialValueToUse
     }
 
     try {
       const raw = window.localStorage.getItem(key)
-      return raw ? deserializer(raw) : initialValue
+      return raw ? deserializer(raw) : initialValueToUse
     } catch (error) {
       console.warn(`Error reading localStorage key “${key}”:`, error)
-      return initialValue
+      return initialValueToUse
     }
   }, [initialValue, key, deserializer])
 

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
@@ -1,5 +1,7 @@
 Persist the state with session storage so that it remains after a page refresh. This can be useful to record session information. This hook is used in the same way as useState except that you must pass the storage key in the 1st parameter. If the window object is not present (as in SSR), `useSessionStorage()` will return the default value.
 
+You can also pass an optional third parameter to use a custom serializer/deserializer.
+
 Related hooks:
 
 - [`useLocalStorage()`](/react-hook/use-local-storage)

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
@@ -53,6 +53,30 @@ describe('useSessionStorage()', () => {
     expect(result.current[0]).toEqual([1, 2])
   })
 
+  test('Initial state is a Map', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage('map', new Map([['a', 1]])),
+    )
+
+    expect(result.current[0]).toEqual(new Map([['a', 1]]))
+  })
+
+  test('Initial state is a Set', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage('set', new Set([1, 2])),
+    )
+
+    expect(result.current[0]).toEqual(new Set([1, 2]))
+  })
+
+  test('Initial state is a Date', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage('date', new Date(2020, 1, 1)),
+    )
+
+    expect(result.current[0]).toEqual(new Date(2020, 1, 1))
+  })
+
   test('Update the state', () => {
     const { result } = renderHook(() => useSessionStorage('key', 'value'))
 

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
@@ -131,6 +131,31 @@ describe('useSessionStorage()', () => {
     expect(C.current[0]).toBe('initial')
   })
 
+  test('[Event] Updating one hook does not update others with a different key', () => {
+    let renderCount = 0
+    const { result: A } = renderHook(() => {
+      renderCount++
+      return useSessionStorage('key1', {})
+    })
+    const { result: B } = renderHook(() => useSessionStorage('key2', 'initial'))
+
+    expect(renderCount).toBe(1)
+
+    act(() => {
+      const setStateA = A.current[1]
+      setStateA({ a: 1 })
+    })
+
+    expect(renderCount).toBe(2)
+
+    act(() => {
+      const setStateB = B.current[1]
+      setStateB('edited')
+    })
+
+    expect(renderCount).toBe(2)
+  })
+
   test('setValue is referentially stable', () => {
     const { result } = renderHook(() => useSessionStorage('count', 1))
 

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
@@ -146,4 +146,56 @@ describe('useSessionStorage()', () => {
 
     expect(result.current[1] === originalCallback).toBe(true)
   })
+
+  test('should use default JSON.stringify and JSON.parse when serializer/deserializer not provided', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage('key', 'initialValue'),
+    )
+
+    act(() => {
+      result.current[1]('newValue')
+    })
+
+    expect(sessionStorage.getItem('key')).toBe(JSON.stringify('newValue'))
+  })
+
+  test('should use custom serializer and deserializer when provided', () => {
+    const serializer = (value: string) => value.toUpperCase()
+    const deserializer = (value: string) => value.toLowerCase()
+
+    const { result } = renderHook(() =>
+      useSessionStorage('key', 'initialValue', { serializer, deserializer }),
+    )
+
+    act(() => {
+      result.current[1]('NewValue')
+    })
+
+    expect(sessionStorage.getItem('key')).toBe('NEWVALUE')
+  })
+
+  test('should handle undefined values with custom deserializer', () => {
+    const serializer = (value: number | undefined) => String(value)
+    const deserializer = (value: string) =>
+      value === 'undefined' ? undefined : Number(value)
+
+    const { result } = renderHook(() =>
+      useSessionStorage<number | undefined>('key', 0, {
+        serializer,
+        deserializer,
+      }),
+    )
+
+    act(() => {
+      result.current[1](undefined)
+    })
+
+    expect(sessionStorage.getItem('key')).toBe('undefined')
+
+    act(() => {
+      result.current[1](42)
+    })
+
+    expect(sessionStorage.getItem('key')).toBe('42')
+  })
 })

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -36,6 +36,15 @@ export function useSessionStorage<T>(
       if (options.serializer) {
         return options.serializer(value)
       }
+
+      if (value instanceof Map) {
+        return JSON.stringify(Object.fromEntries(value))
+      }
+
+      if (value instanceof Set) {
+        return JSON.stringify(Array.from(value))
+      }
+
       return JSON.stringify(value)
     },
     [options],
@@ -50,9 +59,24 @@ export function useSessionStorage<T>(
       if (value === 'undefined') {
         return undefined as unknown as T
       }
-      return JSON.parse(value)
+
+      const parsed = JSON.parse(value)
+
+      if (initialValue instanceof Set) {
+        return new Set(parsed)
+      }
+
+      if (initialValue instanceof Map) {
+        return new Map(Object.entries(parsed))
+      }
+
+      if (initialValue instanceof Date) {
+        return new Date(parsed)
+      }
+
+      return parsed
     },
-    [options],
+    [options, initialValue],
   )
 
   // Get from session storage then

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -14,6 +14,11 @@ declare global {
   }
 }
 
+interface Options<T> {
+  serializer?: (value: T) => string
+  deserializer?: (value: string) => T
+}
+
 type SetValue<T> = Dispatch<SetStateAction<T>>
 
 const IS_SERVER = typeof window === 'undefined'
@@ -21,7 +26,35 @@ const IS_SERVER = typeof window === 'undefined'
 export function useSessionStorage<T>(
   key: string,
   initialValue: T,
+  options: Options<T> = {},
 ): [T, SetValue<T>] {
+  // Pass initial value to support hydration server-client
+  const [storedValue, setStoredValue] = useState<T>(initialValue)
+
+  const serializer = useCallback<(value: T) => string>(
+    value => {
+      if (options.serializer) {
+        return options.serializer(value)
+      }
+      return JSON.stringify(value)
+    },
+    [options],
+  )
+
+  const deserializer = useCallback<(value: string) => T>(
+    value => {
+      if (options.deserializer) {
+        return options.deserializer(value)
+      }
+      // Support 'undefined' as a value
+      if (value === 'undefined') {
+        return undefined as unknown as T
+      }
+      return JSON.parse(value)
+    },
+    [options],
+  )
+
   // Get from session storage then
   // parse stored json or return initialValue
   const readValue = useCallback((): T => {
@@ -31,17 +64,13 @@ export function useSessionStorage<T>(
     }
 
     try {
-      const item = window.sessionStorage.getItem(key)
-      return item ? (parseJSON(item) as T) : initialValue
+      const raw = window.sessionStorage.getItem(key)
+      return raw ? deserializer(raw) : initialValue
     } catch (error) {
       console.warn(`Error reading sessionStorage key “${key}”:`, error)
       return initialValue
     }
-  }, [initialValue, key])
-
-  // State to store our value
-  // Pass initial value to support hydration server-client
-  const [storedValue, setStoredValue] = useState<T>(initialValue)
+  }, [initialValue, key, deserializer])
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to sessionStorage.
@@ -58,7 +87,7 @@ export function useSessionStorage<T>(
       const newValue = value instanceof Function ? value(readValue()) : value
 
       // Save to session storage
-      window.sessionStorage.setItem(key, JSON.stringify(newValue))
+      window.sessionStorage.setItem(key, serializer(newValue))
 
       // Save state
       setStoredValue(newValue)
@@ -93,14 +122,4 @@ export function useSessionStorage<T>(
   useEventListener('session-storage', handleStorageChange)
 
   return [storedValue, setValue]
-}
-
-// A wrapper for "JSON.parse()"" to support "undefined" value
-function parseJSON<T>(value: string | null): T | undefined {
-  try {
-    return value === 'undefined' ? undefined : JSON.parse(value ?? '')
-  } catch {
-    console.warn('parsing error on', { value })
-    return undefined
-  }
 }

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -25,7 +25,7 @@ const IS_SERVER = typeof window === 'undefined'
 
 export function useSessionStorage<T>(
   key: string,
-  initialValue: T,
+  initialValue: T | (() => T),
   options: Options<T> = {},
 ): [T, SetValue<T>] {
   // Pass initial value to support hydration server-client
@@ -58,17 +58,20 @@ export function useSessionStorage<T>(
   // Get from session storage then
   // parse stored json or return initialValue
   const readValue = useCallback((): T => {
+    const initialValueToUse =
+      initialValue instanceof Function ? initialValue() : initialValue
+
     // Prevent build error "window is undefined" but keep keep working
     if (IS_SERVER) {
-      return initialValue
+      return initialValueToUse
     }
 
     try {
       const raw = window.sessionStorage.getItem(key)
-      return raw ? deserializer(raw) : initialValue
+      return raw ? deserializer(raw) : initialValueToUse
     } catch (error) {
       console.warn(`Error reading sessionStorage key “${key}”:`, error)
-      return initialValue
+      return initialValueToUse
     }
   }, [initialValue, key, deserializer])
 


### PR DESCRIPTION
The main feature is to support a custom serializer/deserializer without introducing breaking changes. 

This should fix:
- #240 
- #335 
- #308 
- #309 

This PR in the last commits also fixes missing stuff:
- Added some unit tests to cover #437 
- Updated hook function signature, missing in #436 
- Added Map, Set, and Date built-in support #309 

The work was always done the same on both `useLocalStorage` and `useSessionStorage` (not DRY though 😅 it will be refactored)

Feedback and review are welcome