### PR TITLE
Stringify debounce value in dependency array

### DIFF
--- a/packages/usehooks-ts/src/useDebounce/useDebounce.ts
+++ b/packages/usehooks-ts/src/useDebounce/useDebounce.ts
@@ -9,7 +9,7 @@ export function useDebounce<T>(value: T, delay?: number): T {
     return () => {
       clearTimeout(timer)
     }
-  }, [value, delay])
+  }, [JSON.stringify(value), delay])
 
   return debouncedValue
 }


### PR DESCRIPTION
In reference to #392 . With this change, objects can be debounced. Debounce will only be triggered if a value inside the object is changed, not if the reference itself changes.