### PR TITLE
✨ Feature: declarative SSR

### DIFF
--- a/.changeset/angry-otters-kick.md
+++ b/.changeset/angry-otters-kick.md
@@ -1,0 +1,5 @@
+---
+'usehooks-ts': minor
+---
+
+Pass an optional `{ initializeWithValue?: boolean }` object to make some hooks SSR-safe (useLocalStorage, useReadLocalStorage, useSessionStorage, useDarkMode, useTernaryDarkMode, useMediaQuery, useScreen, useWindowSize, useElementSize)

--- a/.changeset/gorgeous-donuts-grin.md
+++ b/.changeset/gorgeous-donuts-grin.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": minor
+---
+
+Drop Set & Map support in use\*Storage hooks (it was a done before in deserializer, but forgotten in serializer)

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.md
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.md
@@ -2,3 +2,5 @@ This React Hook offers you an interface to set, enable, disable, toggle and read
 The returned value (`isDarkMode`) is a boolean to let you be able to use with your logic.
 
 It uses internally [`useLocalStorage()`](/react-hook/use-local-storage) to persist the value and listens the OS color scheme preferences.
+
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
@@ -5,13 +5,14 @@ import { useUpdateEffect } from '../useUpdateEffect'
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)'
 const LOCAL_STORAGE_KEY = 'usehooks-ts-dark-mode'
 
-type DarkModeOptions = {
+type DarkModeOptions<InitializeWithValue extends boolean | undefined> = {
   defaultValue?: boolean
   localStorageKey?: string
+  initializeWithValue: InitializeWithValue
 }
 
-interface DarkModeOutput {
-  isDarkMode: boolean
+interface DarkModeOutput<T extends boolean | undefined> {
+  isDarkMode: T
   toggle: () => void
   enable: () => void
   disable: () => void
@@ -31,22 +32,17 @@ interface DarkModeOutput {
 export function useDarkMode(
   defaultValue: boolean,
   localStorageKey?: string,
-): DarkModeOutput
+): DarkModeOutput<boolean>
 
-/**
- * Custom hook that returns the current state of the dark mode.
- * @param  {?DarkModeOptions} [options] - Options for the hook.
- * @param {?string} [options.localStorageKey] - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
- * @param {?boolean} [options.defaultValue] - Default value if there's nothing set in local storage (default is `false`).
- * @returns {DarkModeOutput} An object containing the dark mode's state and its controllers.
- * @see [Documentation](https://usehooks-ts.com/react-hook/use-dark-mode)
- * @example
- * const { isDarkMode, toggle, enable, disable, set } = useDarkMode({
- *   defaultValue: false,
- *   localStorageKey: 'my-key',
- * });
- */
-export function useDarkMode(options?: DarkModeOptions): DarkModeOutput
+// SSR version of useDarkMode.
+export function useDarkMode(
+  options: DarkModeOptions<false>,
+): DarkModeOutput<boolean | undefined>
+
+// CSR version of useDarkMode.
+export function useDarkMode(
+  options?: Partial<DarkModeOptions<true>>,
+): DarkModeOutput<boolean>
 
 /**
  * Custom hook that returns the current state of the dark mode.
@@ -58,9 +54,9 @@ export function useDarkMode(options?: DarkModeOptions): DarkModeOutput
  * const { isDarkMode, toggle, enable, disable, set } = useDarkMode({ defaultValue: true });
  */
 export function useDarkMode(
-  options?: boolean | DarkModeOptions,
+  options?: boolean | Partial<DarkModeOptions<boolean>>,
   localStorageKeyProps: string = LOCAL_STORAGE_KEY,
-): DarkModeOutput {
+): DarkModeOutput<boolean | undefined> {
   // TODO: Refactor this code after the deprecated signature has been removed.
   const defaultValue =
     typeof options === 'boolean' ? options : options?.defaultValue ?? false
@@ -68,11 +64,16 @@ export function useDarkMode(
     typeof options === 'boolean'
       ? localStorageKeyProps ?? LOCAL_STORAGE_KEY
       : options?.localStorageKey ?? LOCAL_STORAGE_KEY
+  const initializeWithValue =
+    typeof options === 'boolean'
+      ? undefined
+      : options?.initializeWithValue ?? undefined
 
   const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY)
   const [isDarkMode, setDarkMode] = useLocalStorage<boolean>(
     localStorageKey,
     defaultValue ?? isDarkOS ?? false,
+    { initializeWithValue },
   )
 
   // Update darkMode if os prefers changes

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
@@ -46,7 +46,10 @@ export function useDarkMode(
 
 /**
  * Custom hook that returns the current state of the dark mode.
- * @param  {?boolean | ?DarkModeOptions} [options] the initial value of the dark mode, default `false`.
+ * @param  {?boolean | ?DarkModeOptions} [options] - the initial value of the dark mode, default `false`.
+ * @param  {?boolean} [options.defaultValue] - the initial value of the dark mode, default `false`.
+ * @param  {?string} [options.localStorageKey] - the key to use in the local storage, default `'usehooks-ts-dark-mode'`.
+ * @param  {?boolean} [options.initializeWithValue] - if `true` (default), the hook will initialize reading `localStorage`. In SSR, you should set it to `false`, returning `undefined` or the `defaultValue` initially.
  * @param  {?string} [localStorageKeyProps] the key to use in the local storage, default `'usehooks-ts-dark-mode'`.
  * @returns {DarkModeOutput} An object containing the dark mode's state and its controllers.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-dark-mode)

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.md
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.md
@@ -1,2 +1,4 @@
 This hook helps you to dynamically recover the width and the height of an HTML element.
 Dimensions are updated on load, on mount/un-mount, when resizing the window and when the ref changes.
+
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.ts
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.ts
@@ -3,14 +3,29 @@ import { useCallback, useState } from 'react'
 import { useEventListener } from '../useEventListener'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
-interface Size {
-  width: number
-  height: number
+interface Size<W extends number = number, T extends number = number> {
+  width: W
+  height: T
 }
 
+type UseElementSizeOptions<InitializeWithValue extends boolean | undefined> = {
+  initializeWithValue: InitializeWithValue
+}
+
+const IS_SERVER = typeof window === 'undefined'
+
+// SSR version of useElementSize.
+export function useElementSize<T extends HTMLElement = HTMLDivElement>(
+  options: UseElementSizeOptions<false>,
+): [(node: T | null) => void, Size<0, 0>]
+// CSR version of useElementSize.
+export function useElementSize<T extends HTMLElement = HTMLDivElement>(
+  options?: Partial<UseElementSizeOptions<true>>,
+): [(node: T | null) => void, Size]
 /**
  * A hook for tracking the size of a DOM element.
  * @template T - The type of the DOM element. Defaults to `HTMLDivElement`.
+ * @param {?UseElementSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
  * @returns {[ (node: T | null) => void, Size ]} A tuple containing a ref-setting function and the size of the element.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-element-size)
  * @example
@@ -22,29 +37,41 @@ interface Size {
  *   </div>
  * );
  */
-export function useElementSize<T extends HTMLElement = HTMLDivElement>(): [
-  (node: T | null) => void,
-  Size,
-] {
+export function useElementSize<T extends HTMLElement = HTMLDivElement>(
+  options: Partial<UseElementSizeOptions<boolean>> = {},
+): [(node: T | null) => void, Size] {
+  let { initializeWithValue = true } = options
+  if (IS_SERVER) {
+    initializeWithValue = false
+  }
+
   // Mutable values like 'ref.current' aren't valid dependencies
   // because mutating them doesn't re-render the component.
   // Instead, we use a state as a ref to be reactive.
   const [ref, setRef] = useState<T | null>(null)
-  const [size, setSize] = useState<Size>({
-    width: 0,
-    height: 0,
+
+  const readValue = useCallback(() => {
+    return {
+      width: ref?.offsetWidth ?? 0,
+      height: ref?.offsetHeight ?? 0,
+    }
+  }, [ref?.offsetHeight, ref?.offsetWidth])
+
+  const [size, setSize] = useState(() => {
+    if (initializeWithValue) {
+      return readValue()
+    }
+    return { width: 0, height: 0 }
   })
 
   // Prevent too many rendering using useCallback
   const handleSize = useCallback(() => {
-    setSize({
-      width: ref?.offsetWidth ?? 0,
-      height: ref?.offsetHeight ?? 0,
-    })
+    setSize(readValue())
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref?.offsetHeight, ref?.offsetWidth])
 
+  // TODO: Prefer incoming useResizeObserver hook
   useEventListener('resize', handleSize)
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.ts
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.ts
@@ -26,6 +26,7 @@ export function useElementSize<T extends HTMLElement = HTMLDivElement>(
  * A hook for tracking the size of a DOM element.
  * @template T - The type of the DOM element. Defaults to `HTMLDivElement`.
  * @param {?UseElementSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the element's size. In SSR, you should set it to `false`, returning `{ width: 0, height: 0 }` initially.
  * @returns {[ (node: T | null) => void, Size ]} A tuple containing a ref-setting function and the size of the element.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-element-size)
  * @example

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
@@ -1,14 +1,12 @@
-Persist the state with local storage so that it remains after a page refresh. This can be useful for a dark theme.
+Persist the state with [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) so that it remains after a page refresh. This can be useful for a dark theme.
 This hook is used in the same way as useState except that you must pass the storage key in the 1st parameter.
-If the window object is not present (as in SSR), `useLocalStorage()` will return the default value.
 
 You can also pass an optional third parameter to use a custom serializer/deserializer.
 
-**Side notes:**
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
 
-- If you really want to create a dark theme switch, see [useDarkMode()](/react-hook/use-dark-mode).
-- If you just want read value from local storage, see [useReadLocalStorage()](/react-hook/use-read-local-storage).
+### Related hooks
 
-Related hooks:
-
-- [`useSessionStorage()`](/react-hook/use-session-storage)
+- [`useDarkMode()`](/react-hook/use-dark-mode): Helps create a dark theme switch, built on top of `useLocalStorage()`.
+- [`useReadLocalStorage()`](/react-hook/use-read-local-storage): Read values from local storage.
+- [`useSessionStorage()`](/react-hook/use-session-storage): Its implementation is almost the same of `useLocalStorage()`, but on [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) instead.

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -15,13 +15,6 @@ declare global {
   }
 }
 
-/**
- * Represents the options for customizing the behavior of serialization and deserialization.
- * @template T - The type of the state to be stored in local storage.
- * @interface Options
- * @property {(value: T) => string} [serializer] - A function to serialize the value before storing it.
- * @property {(value: string) => T} [deserializer] - A function to deserialize the stored value.
- */
 interface UseLocalStorageOptions<
   T,
   InitializeWithValue extends boolean | undefined,
@@ -52,6 +45,9 @@ export function useLocalStorage<T>(
  * @param {string} key - The key under which the value will be stored in local storage.
  * @param {T | (() => T)} initialValue - The initial value of the state or a function that returns the initial value.
  * @param {UseLocalStorageOptions<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the local storage. In SSR, you should set it to `false`, returning `undefined` initially.
+ * @param {?((value: T) => string)} [options.serializer] - A function to serialize the value before storing it.
+ * @param {?((value: string) => T)} [options.deserializer] - A function to deserialize the stored value.
  * @returns {[T, Dispatch<SetStateAction<T>>]} A tuple containing the stored value and a function to set the value.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-local-storage)
  * @see [MDN Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -22,21 +22,36 @@ declare global {
  * @property {(value: T) => string} [serializer] - A function to serialize the value before storing it.
  * @property {(value: string) => T} [deserializer] - A function to deserialize the stored value.
  */
-interface Options<T> {
+interface UseLocalStorageOptions<
+  T,
+  InitializeWithValue extends boolean | undefined,
+> {
   serializer?: (value: T) => string
   deserializer?: (value: string) => T
+  initializeWithValue: InitializeWithValue
 }
-
-type SetValue<T> = Dispatch<SetStateAction<T>>
 
 const IS_SERVER = typeof window === 'undefined'
 
+// SSR version of useLocalStorage.
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UseLocalStorageOptions<T, false>,
+): [T | undefined, Dispatch<SetStateAction<T>>]
+
+// CSR version of useLocalStorage.
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options?: Partial<UseLocalStorageOptions<T, boolean>>,
+): [T, Dispatch<SetStateAction<T>>]
 /**
  * Custom hook for using local storage to persist state across page reloads.
  * @template T - The type of the state to be stored in local storage.
  * @param {string} key - The key under which the value will be stored in local storage.
  * @param {T | (() => T)} initialValue - The initial value of the state or a function that returns the initial value.
- * @param {Options<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
+ * @param {UseLocalStorageOptions<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
  * @returns {[T, Dispatch<SetStateAction<T>>]} A tuple containing the stored value and a function to set the value.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-local-storage)
  * @see [MDN Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
@@ -47,23 +62,17 @@ const IS_SERVER = typeof window === 'undefined'
 export function useLocalStorage<T>(
   key: string,
   initialValue: T | (() => T),
-  options: Options<T> = {},
-): [T, SetValue<T>] {
-  // Pass initial value to support hydration server-client
-  const [storedValue, setStoredValue] = useState<T>(initialValue)
+  options: Partial<UseLocalStorageOptions<T, boolean>> = {},
+): [T | undefined, Dispatch<SetStateAction<T>>] {
+  let { initializeWithValue = true } = options
+  if (IS_SERVER) {
+    initializeWithValue = false
+  }
 
   const serializer = useCallback<(value: T) => string>(
     value => {
       if (options.serializer) {
         return options.serializer(value)
-      }
-
-      if (value instanceof Map) {
-        return JSON.stringify(Object.fromEntries(value))
-      }
-
-      if (value instanceof Set) {
-        return JSON.stringify(Array.from(value))
       }
 
       return JSON.stringify(value)
@@ -117,9 +126,16 @@ export function useLocalStorage<T>(
     }
   }, [initialValue, key, deserializer])
 
+  const [storedValue, setStoredValue] = useState(() => {
+    if (initializeWithValue) {
+      return readValue()
+    }
+    return undefined
+  })
+
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.
-  const setValue: SetValue<T> = useEventCallback(value => {
+  const setValue: Dispatch<SetStateAction<T>> = useEventCallback(value => {
     // Prevent build error "window is undefined" but keeps working
     if (IS_SERVER) {
       console.warn(

--- a/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.md
+++ b/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.md
@@ -2,4 +2,5 @@ Easily retrieve media dimensions with this Hook React which also works onResize.
 
 **Note:**
 
-Before Safari 14, `MediaQueryList` is based on `EventTarget` and only supports `addListener`/`removeListener` for media queries. If you don't support these versions you may remove these checks. Read more about this on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener).
+- If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+- Before Safari 14, `MediaQueryList` is based on `EventTarget` and only supports `addListener`/`removeListener` for media queries. If you don't support these versions you may remove these checks. Read more about this on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener).

--- a/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
@@ -36,7 +36,9 @@ export function useMediaQuery(
  * Custom hook for tracking the state of a media query.
  * @param {string} query - The media query to track.
  * @param {boolean | ?UseMediaQueryOptions} [options] - The default value to return if the hook is being run on the server (default is `false`).
- * @returns {boolean} The current state of the media query (true if the query matches, false otherwise).
+ * @param {?boolean} [options.defaultValue] - The default value to return if the hook is being run on the server (default is `false`).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the media query. In SSR, you should set it to `false`, returning `undefined`  or `options.defaultValue` initially.
+ * @returns {boolean | undefined} The current state of the media query (true if the query matches, false otherwise).
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-media-query)
  * @see [MDN Match Media](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)
  * @example
@@ -46,7 +48,7 @@ export function useMediaQuery(
 export function useMediaQuery(
   query: string,
   options?: boolean | Partial<UseMediaQueryOptions<boolean>>,
-): boolean {
+): boolean | undefined {
   // TODO: Refactor this code after the deprecated signature has been removed.
   const defaultValue =
     typeof options === 'boolean' ? options : options?.defaultValue ?? false

--- a/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.md
+++ b/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.md
@@ -3,4 +3,5 @@ If the window object is not present (as in SSR), or if the value doesn't exist, 
 
 **Note:**
 
-If you want to be able to change the value, see [useLocalStorage()](/react-hook/use-local-storage).
+- If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+- If you want to be able to change the value, see [useLocalStorage()](/react-hook/use-local-storage).

--- a/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.ts
+++ b/packages/usehooks-ts/src/useReadLocalStorage/useReadLocalStorage.ts
@@ -32,6 +32,7 @@ export function useReadLocalStorage<T>(
  * @param {string} key - The key associated with the value in local storage.
  * @param {Options<T>} [options] - Additional options for reading the value (optional).
  * @param {(value: string) => T} [options.deserializer] - Custom deserializer function to convert the stored string value to the desired type (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the local storage. In SSR, you should set it to `false`, returning `undefined` initially.
  * @returns {Value<T> | undefined} The stored value, or null if the key is not present or an error occurs.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-read-local-storage)
  * @example

--- a/packages/usehooks-ts/src/useScreen/useScreen.md
+++ b/packages/usehooks-ts/src/useScreen/useScreen.md
@@ -1,1 +1,3 @@
 Easily retrieve `window.screen` object with this Hook React which also works onResize.
+
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.

--- a/packages/usehooks-ts/src/useScreen/useScreen.ts
+++ b/packages/usehooks-ts/src/useScreen/useScreen.ts
@@ -3,27 +3,43 @@ import { useState } from 'react'
 import { useEventListener } from '../useEventListener'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
+type UseScreenOptions<InitializeWithValue extends boolean | undefined> = {
+  initializeWithValue: InitializeWithValue
+}
+
+const IS_SERVER = typeof window === 'undefined'
+
+// SSR version of useScreen.
+export function useScreen(options: UseScreenOptions<false>): Screen | undefined
+// CSR version of useScreen.
+export function useScreen(options?: Partial<UseScreenOptions<true>>): Screen
 /**
  * Custom hook for tracking the screen dimensions and properties.
+ * @param {?UseScreenOptions} [options] - The options for customizing the behavior of the hook (optional).
  * @returns {Screen | undefined} The current `Screen` object representing the screen dimensions and properties, or `undefined` if not available.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-screen)
  * @example
  * const currentScreen = useScreen();
  * // Access properties of the current screen, such as width and height.
  */
-export function useScreen(): Screen | undefined {
-  const getScreen = () => {
-    if (typeof window !== 'undefined') {
+export function useScreen(
+  options: Partial<UseScreenOptions<boolean>> = {},
+): Screen | undefined {
+  let { initializeWithValue = true } = options
+  if (IS_SERVER) {
+    initializeWithValue = false
+  }
+
+  const [screen, setScreen] = useState<Screen | undefined>(() => {
+    if (initializeWithValue) {
       return window.screen
     }
     return undefined
-  }
-
-  const [screen, setScreen] = useState<Screen | undefined>(undefined)
+  })
 
   /** Handles the resize event of the window. */
   function handleSize() {
-    setScreen(getScreen())
+    setScreen(window.screen)
   }
 
   // TODO: Prefer incoming useResizeObserver hook

--- a/packages/usehooks-ts/src/useScreen/useScreen.ts
+++ b/packages/usehooks-ts/src/useScreen/useScreen.ts
@@ -16,6 +16,7 @@ export function useScreen(options?: Partial<UseScreenOptions<true>>): Screen
 /**
  * Custom hook for tracking the screen dimensions and properties.
  * @param {?UseScreenOptions} [options] - The options for customizing the behavior of the hook (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the screen dimensions. In SSR, you should set it to `false`, returning `undefined` initially.
  * @returns {Screen | undefined} The current `Screen` object representing the screen dimensions and properties, or `undefined` if not available.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-screen)
  * @example

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
@@ -2,6 +2,8 @@ Persist the state with session storage so that it remains after a page refresh. 
 
 You can also pass an optional third parameter to use a custom serializer/deserializer.
 
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+
 Related hooks:
 
 - [`useLocalStorage()`](/react-hook/use-local-storage)

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -53,7 +53,9 @@ export function useSessionStorage<T>(
  * @template T - The type of the state to be stored in session storage.
  * @param {string} key - The key under which the value will be stored in session storage.
  * @param {T | (() => T)} initialValue - The initial value of the state or a function that returns the initial value.
- * @param {UseSessionStorageOptions<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
+ * @param {?UseSessionStorageOptions<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the session storage. In SSR, you should set it to `false`, returning `undefined` initially.
+ * @param {(value: T) => string} [options.serializer] - A function to serialize the value before storing it.
  * @returns {[T, Dispatch<SetStateAction<T>>]} A tuple containing the stored value and a function to set the value.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-session-storage)
  * @see [MDN Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.ts
@@ -22,20 +22,38 @@ declare global {
  * @property {(value: T) => string} [serializer] - A function to serialize the value before storing it.
  * @property {(value: string) => T} [deserializer] - A function to deserialize the stored value.
  */
-interface Options<T> {
+interface UseSessionStorageOptions<
+  T,
+  InitializeWithValue extends boolean | undefined,
+> {
   serializer?: (value: T) => string
   deserializer?: (value: string) => T
+  initializeWithValue: InitializeWithValue
 }
 
-type SetValue<T> = Dispatch<SetStateAction<T>>
+// type SetValue<T> = Dispatch<SetStateAction<T>>
 
 const IS_SERVER = typeof window === 'undefined'
+
+// SSR version of useSessionStorage.
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UseSessionStorageOptions<T, false>,
+): [T | undefined, Dispatch<SetStateAction<T>>]
+
+// CSR version of useSessionStorage.
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options?: Partial<UseSessionStorageOptions<T, boolean>>,
+): [T, Dispatch<SetStateAction<T>>]
 /**
  * Custom hook for using session storage to persist state across page reloads.
  * @template T - The type of the state to be stored in session storage.
  * @param {string} key - The key under which the value will be stored in session storage.
  * @param {T | (() => T)} initialValue - The initial value of the state or a function that returns the initial value.
- * @param {Options<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
+ * @param {UseSessionStorageOptions<T>} [options] - Options for customizing the behavior of serialization and deserialization (optional).
  * @returns {[T, Dispatch<SetStateAction<T>>]} A tuple containing the stored value and a function to set the value.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-session-storage)
  * @see [MDN Session Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
@@ -46,23 +64,17 @@ const IS_SERVER = typeof window === 'undefined'
 export function useSessionStorage<T>(
   key: string,
   initialValue: T | (() => T),
-  options: Options<T> = {},
-): [T, SetValue<T>] {
-  // Pass initial value to support hydration server-client
-  const [storedValue, setStoredValue] = useState<T>(initialValue)
+  options: Partial<UseSessionStorageOptions<T, boolean>> = {},
+): [T | undefined, Dispatch<SetStateAction<T>>] {
+  let { initializeWithValue = true } = options
+  if (IS_SERVER) {
+    initializeWithValue = false
+  }
 
   const serializer = useCallback<(value: T) => string>(
     value => {
       if (options.serializer) {
         return options.serializer(value)
-      }
-
-      if (value instanceof Map) {
-        return JSON.stringify(Object.fromEntries(value))
-      }
-
-      if (value instanceof Set) {
-        return JSON.stringify(Array.from(value))
       }
 
       return JSON.stringify(value)
@@ -116,9 +128,16 @@ export function useSessionStorage<T>(
     }
   }, [initialValue, key, deserializer])
 
+  const [storedValue, setStoredValue] = useState(() => {
+    if (initializeWithValue) {
+      return readValue()
+    }
+    return undefined
+  })
+
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to sessionStorage.
-  const setValue: SetValue<T> = useEventCallback(value => {
+  const setValue: Dispatch<SetStateAction<T>> = useEventCallback(value => {
     // Prevent build error "window is undefined" but keeps working
     if (IS_SERVER) {
       console.warn(

--- a/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.demo.tsx
+++ b/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.demo.tsx
@@ -1,4 +1,4 @@
-import { useTernaryDarkMode } from './useTernaryDarkMode'
+import { type TernaryDarkMode, useTernaryDarkMode } from './useTernaryDarkMode'
 
 export default function Component() {
   const {
@@ -7,7 +7,6 @@ export default function Component() {
     setTernaryDarkMode,
     toggleTernaryDarkMode,
   } = useTernaryDarkMode()
-  type TernaryDarkMode = typeof ternaryDarkMode
 
   return (
     <div>
@@ -25,6 +24,7 @@ export default function Component() {
         <select
           name="select-ternaryDarkMode"
           onChange={ev => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             setTernaryDarkMode(ev.target.value as TernaryDarkMode)
           }}
           value={ternaryDarkMode}

--- a/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.md
+++ b/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.md
@@ -2,6 +2,8 @@ This React Hook offers you an interface to toggle and read the dark theme mode b
 
 If no value exists in local storage, it will default to `"system"`, though this can be changed by using the `defaultValue` hook parameter.
 
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+
 Returned value
 
 - The `isDarkMode` is a boolean for the final outcome, to let you be able to use with your logic.

--- a/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
+++ b/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
@@ -6,25 +6,29 @@ import { useMediaQuery } from '../useMediaQuery'
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)'
 const LOCAL_STORAGE_KEY = 'usehooks-ts-ternary-dark-mode'
 
-type TernaryDarkMode = 'system' | 'dark' | 'light'
+export type TernaryDarkMode = 'system' | 'dark' | 'light'
 
-type TernaryDarkModeOptions = {
+type TernaryDarkModeOptions<InitializeWithValue extends boolean | undefined> = {
   defaultValue?: TernaryDarkMode
   localStorageKey?: string
+  initializeWithValue: InitializeWithValue
 }
 
-interface TernaryDarkModeOutput {
-  isDarkMode: boolean
-  ternaryDarkMode: TernaryDarkMode
+type ReturnedMethods = {
   setTernaryDarkMode: Dispatch<SetStateAction<TernaryDarkMode>>
   toggleTernaryDarkMode: () => void
+}
+
+type ReturnedValues = {
+  isDarkMode: boolean
+  ternaryDarkMode: TernaryDarkMode
 }
 
 /**
  * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
  * @deprecated this useTernaryDarkMode's signature is deprecated, it now accepts an options object instead of multiple parameters.
  * @param {string} localStorageKey - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
- * @returns {TernaryDarkModeOutput} An object containing the dark mode state and helper functions.
+ * @returns {ReturnedMethods & ReturnedValues} An object containing the dark mode state and helper functions.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
  * @example
  * const { isDarkMode, ternaryDarkMode, setTernaryDarkMode, toggleTernaryDarkMode } = useTernaryDarkMode('my-key');
@@ -32,35 +36,30 @@ interface TernaryDarkModeOutput {
  */
 export function useTernaryDarkMode(
   localStorageKey: string,
-): TernaryDarkModeOutput
+): ReturnedMethods & ReturnedValues
 
-/**
- * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
- * @param {?TernaryDarkModeOptions} [options] - Options for the hook.
- * @param {?string} [options.localStorageKey] - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
- * @param {?TernaryDarkMode} [options.defaultValue] - Default value if there's nothing set in local storage (default is `'system'`).
- * @returns {TernaryDarkModeOutput} An object containing the dark mode state and helper functions.
- * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
- * @example
- * const { isDarkMode, ternaryDarkMode, setTernaryDarkMode, toggleTernaryDarkMode } = useTernaryDarkMode({ defaultValue: 'dark', localStorageKey: 'my-key' });
- * // Access and use the dark mode state and provided helper functions.
- */
+// SSR version of useTernaryDarkMode.
 export function useTernaryDarkMode(
-  options?: TernaryDarkModeOptions,
-): TernaryDarkModeOutput
+  options: TernaryDarkModeOptions<false>,
+): ReturnedMethods & Partial<ReturnedValues>
+
+// CSR version of useTernaryDarkMode.
+export function useTernaryDarkMode(
+  options?: Partial<TernaryDarkModeOptions<true>>,
+): ReturnedMethods & ReturnedValues
 
 /**
  * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
  * @param {TernaryDarkModeOptions | string} [options] - Options or the local storage key for the hook.
- * @returns {TernaryDarkModeOutput} An object containing the dark mode state and helper functions.
+ * @returns {ReturnedMethods & Partial<ReturnedValues>} An object containing the dark mode state and helper functions.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
  * @example
  * const { isDarkMode, ternaryDarkMode, setTernaryDarkMode, toggleTernaryDarkMode } = useTernaryDarkMode({ defaultValue: 'dark' });
  * // Access and use the dark mode state and provided helper functions.
  */
 export function useTernaryDarkMode(
-  options?: string | TernaryDarkModeOptions,
-): TernaryDarkModeOutput {
+  options?: string | Partial<TernaryDarkModeOptions<boolean>>,
+): ReturnedMethods & Partial<ReturnedValues> {
   // TODO: Refactor this code after the deprecated signature has been removed.
   const defaultValue =
     typeof options === 'string' ? 'system' : options?.defaultValue ?? 'system'
@@ -68,9 +67,15 @@ export function useTernaryDarkMode(
     typeof options === 'string'
       ? options
       : options?.localStorageKey ?? LOCAL_STORAGE_KEY
+  const initializeWithValue =
+    typeof options === 'string'
+      ? undefined
+      : options?.initializeWithValue ?? undefined
 
   const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY)
-  const [mode, setMode] = useLocalStorage(localStorageKey, defaultValue)
+  const [mode, setMode] = useLocalStorage(localStorageKey, defaultValue, {
+    initializeWithValue,
+  })
 
   const isDarkMode = mode === 'dark' || (mode === 'system' && isDarkOS)
 

--- a/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
+++ b/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
@@ -50,7 +50,10 @@ export function useTernaryDarkMode(
 
 /**
  * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
- * @param {TernaryDarkModeOptions | string} [options] - Options or the local storage key for the hook.
+ * @param {?TernaryDarkModeOptions | string} [options] - Options or the local storage key for the hook.
+ * @param {?string} [options.localStorageKey] - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
+ * @param {?TernaryDarkMode} [options.defaultValue] - The default value for the dark mode (default is `'system'`).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading `localStorage`. In SSR, you should set it to `false`, returning `undefined` initially.
  * @returns {ReturnedMethods & Partial<ReturnedValues>} An object containing the dark mode state and helper functions.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
  * @example

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.demo.tsx
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.demo.tsx
@@ -1,12 +1,11 @@
 import { useWindowSize } from './useWindowSize'
 
 export default function Component() {
-  const { width, height } = useWindowSize()
+  const size = useWindowSize()
 
   return (
     <div>
-      The current window dimensions are:{' '}
-      <code>{JSON.stringify({ width, height })}</code>
+      The current window dimensions are: <code>{JSON.stringify(size)}</code>
     </div>
   )
 }

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.md
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.md
@@ -1,1 +1,3 @@
 Easily retrieve window dimensions with this React Hook which also works onResize.
+
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
@@ -8,8 +8,23 @@ interface WindowSize {
   height: number
 }
 
+type UseWindowSizeOptions<InitializeWithValue extends boolean | undefined> = {
+  initializeWithValue: InitializeWithValue
+}
+
+const IS_SERVER = typeof window === 'undefined'
+
+// SSR version of useWindowSize.
+export function useWindowSize(
+  options: UseWindowSizeOptions<false>,
+): WindowSize | undefined
+// CSR version of useWindowSize.
+export function useWindowSize(
+  options?: Partial<UseWindowSizeOptions<true>>,
+): WindowSize
 /**
  * Custom hook that tracks the size of the window.
+ * @param {?UseWindowSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
  * @returns {object} An object containing the width and height of the window.
  * @property {number} width - The width of the window.
  * @property {number} height - The height of the window.
@@ -19,10 +34,22 @@ interface WindowSize {
  * const { width, height } = useWindowSize();
  * console.log(`Window size: ${width} x ${height}`);
  */
-export function useWindowSize(): WindowSize {
-  const [windowSize, setWindowSize] = useState<WindowSize>({
-    width: 0,
-    height: 0,
+export function useWindowSize(
+  options: Partial<UseWindowSizeOptions<boolean>> = {},
+): WindowSize | undefined {
+  let { initializeWithValue = true } = options
+  if (IS_SERVER) {
+    initializeWithValue = false
+  }
+
+  const [windowSize, setWindowSize] = useState(() => {
+    if (initializeWithValue) {
+      return {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }
+    }
+    return undefined
   })
 
   const handleSize = () => {
@@ -32,6 +59,7 @@ export function useWindowSize(): WindowSize {
     })
   }
 
+  // TODO: Prefer incoming useResizeObserver hook
   useEventListener('resize', handleSize)
 
   // Set size at the first client-side load

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
@@ -25,6 +25,7 @@ export function useWindowSize(
 /**
  * Custom hook that tracks the size of the window.
  * @param {?UseWindowSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the window size. In SSR, you should set it to `false`, returning `undefined` initially.
  * @returns {object} An object containing the width and height of the window.
  * @property {number} width - The width of the window.
  * @property {number} height - The height of the window.


### PR DESCRIPTION
## Description

- In CSR (eg: CRA, vite), we want to read browser API (`matchMedia`, `localStorage`...) asap.
- In SSR (eg: Next.js), the `window` is not defined, and trying to read it asap could generate a hydration mismatch. 

This PR adds an `initializeWithValue` option (default to `true`) to choose the mode (CSR/SSR). Basically, setting `false` in the SSR context is required and will return either `undefined` or the given `defaultValue` when available.

Passing `initializeWithValue` gives an SSR-friendly API while keeping strong typing. The trick is done using "method overloading" and returns this kind of typing:

```ts
const defaultCsr /* boolean */ = useMediaQuery('(max-width: 600px)')
const ssr /* boolean | undefined */ = useMediaQuery('(max-width: 600px)', {
  initializeWithValue: false,
})
const csr /* boolean */ = useMediaQuery('(max-width: 600px)', {
  initializeWithValue: true,
})

```

### Updated hooks

- `useLocalStorage`
- `useReadLocalStorage`
- `useSessionStorage`
- `useDarkMode`
- `useTernaryDarkMode`
- `useMediaQuery`
- `useScreen`
- `useWindowSize`
- `useElementSize`

### Additional

- A previous PR removed the `Map`, `Set` and `Date` supports from `use***Storage` hooks. It was done in deserializers only. I fixed it here by also removing it from serializers