### PR TITLE
fix: move `lodash.debounce` to `dependencies` from `peerDependencies`

### DIFF
--- a/.changeset/pink-ravens-fix.md
+++ b/.changeset/pink-ravens-fix.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+move `lodash.debounce` to dependencies from peerDependencies

--- a/packages/usehooks-ts/package.json
+++ b/packages/usehooks-ts/package.json
@@ -48,14 +48,11 @@
     "vite": "^5.0.12",
     "vitest": "^1.2.2"
   },
-  "peerDependencies": {
-    "lodash.debounce": "^4",
-    "react": "^16.8.0  || ^17 || ^18"
+  "dependencies": {
+    "lodash.debounce": "^4.0.8"
   },
-  "peerDependenciesMeta": {
-    "lodash.debounce": {
-      "optional": true
-    }
+  "peerDependencies": {
+    "react": "^16.8.0  || ^17 || ^18"
   },
   "engines": {
     "node": ">=16.15.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
   packages/usehooks-ts:
     dependencies:
       lodash.debounce:
-        specifier: ^4
+        specifier: ^4.0.8
         version: 4.0.8
     devDependencies:
       '@testing-library/jest-dom':


### PR DESCRIPTION
Moved `lodash.debounce` to `dependencies` from `peerDependencies`.

Fixes #458, #452, #453

More info about the bug in #458