### PR TITLE
🐛 Fix: SSR hooks now fallback with default or initial value instead of `undefined`

### DIFF
--- a/.changeset/flat-radios-notice.md
+++ b/.changeset/flat-radios-notice.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": minor
+---
+
+Fix SSR hooks by fallback with default or initial value instead of `undefined`

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.test.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.test.ts
@@ -130,7 +130,10 @@ describe('useDarkMode()', () => {
   })
 
   it('should accept a custom default value', () => {
-    const { result } = renderHook(() => useDarkMode({ defaultValue: true }))
+    mockMatchMedia(true)
+    const { result } = renderHook(() =>
+      useDarkMode({ defaultValue: true, initializeWithValue: false }),
+    )
 
     expect(result.current.isDarkMode).toBe(true)
 

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.demo.tsx
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.demo.tsx
@@ -4,7 +4,7 @@ import { useElementSize } from './useElementSize'
 
 export default function Component() {
   const [isVisible, setVisible] = useState(true)
-  const [squareRef, { width, height }] = useElementSize()
+  const [squareRef, { width = 0, height = 0 }] = useElementSize()
 
   const toggleVisibility = () => {
     setVisible(x => !x)

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.md
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.md
@@ -1,4 +1,4 @@
 This hook helps you to dynamically recover the width and the height of an HTML element.
 Dimensions are updated on load, on mount/un-mount, when resizing the window and when the ref changes.
 
-**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `{ width: undefined, height: undefined }` (You can pass it default values when initializing the hook, see example below).

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.test.ts
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.test.ts
@@ -54,11 +54,16 @@ describe('useElementSize()', () => {
 
   it('should initialize', () => {
     const { result } = setupHook()
-    const [setRef, size] = result.current
 
-    expect(typeof size.height).toBe('number')
-    expect(typeof size.width).toBe('number')
-    expect(setRef).toBeInstanceOf(Function)
+    act(() => {
+      result.current.ref(dom)
+      resizeElement(dom, 'width', 1920)
+      resizeElement(dom, 'height', 1080)
+    })
+
+    expect(typeof result.current.height).toBe('number')
+    expect(typeof result.current.width).toBe('number')
+    expect(result.current.ref).toBeInstanceOf(Function)
   })
 
   it('should match the corresponding height', () => {

--- a/packages/usehooks-ts/src/useElementSize/useElementSize.ts
+++ b/packages/usehooks-ts/src/useElementSize/useElementSize.ts
@@ -3,34 +3,30 @@ import { useCallback, useState } from 'react'
 import { useEventListener } from '../useEventListener'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
-interface Size<W extends number = number, T extends number = number> {
-  width: W
-  height: T
+type Size = {
+  width: number | undefined
+  height: number | undefined
 }
 
-type UseElementSizeOptions<InitializeWithValue extends boolean | undefined> = {
-  initializeWithValue: InitializeWithValue
+type UseElementSizeOptions = {
+  initializeWithValue?: boolean
 }
 
-const IS_SERVER = typeof window === 'undefined'
+/** Supports both array and object destructing */
+type UseElementSizeResult = [(node: Element | null) => void, Size] &
+  (Size & { ref: (node: Element | null) => void })
 
-// SSR version of useElementSize.
-export function useElementSize<T extends HTMLElement = HTMLDivElement>(
-  options: UseElementSizeOptions<false>,
-): [(node: T | null) => void, Size<0, 0>]
-// CSR version of useElementSize.
-export function useElementSize<T extends HTMLElement = HTMLDivElement>(
-  options?: Partial<UseElementSizeOptions<true>>,
-): [(node: T | null) => void, Size]
 /**
  * A hook for tracking the size of a DOM element.
  * @template T - The type of the DOM element. Defaults to `HTMLDivElement`.
  * @param {?UseElementSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
- * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the element's size. In SSR, you should set it to `false`, returning `{ width: 0, height: 0 }` initially.
- * @returns {[ (node: T | null) => void, Size ]} A tuple containing a ref-setting function and the size of the element.
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the element's size. In SSR, you should set it to `false`.
+ * @returns The ref-setting function and the size of the element. Either as an tuple [ref, size] or as an object { ref, width, height }.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-element-size)
  * @example
- * const [ref, size] = useElementSize();
+ * const [ref, { width = 0, height = 0 }] = useElementSize();
+ * // or
+ * const { ref, width = 0, height = 0 } = useElementSize();
  *
  * return (
  *   <div ref={ref}>
@@ -39,30 +35,27 @@ export function useElementSize<T extends HTMLElement = HTMLDivElement>(
  * );
  */
 export function useElementSize<T extends HTMLElement = HTMLDivElement>(
-  options: Partial<UseElementSizeOptions<boolean>> = {},
-): [(node: T | null) => void, Size] {
-  let { initializeWithValue = true } = options
-  if (IS_SERVER) {
-    initializeWithValue = false
-  }
+  options: UseElementSizeOptions = {},
+): UseElementSizeResult {
+  const { initializeWithValue = true } = options
 
   // Mutable values like 'ref.current' aren't valid dependencies
   // because mutating them doesn't re-render the component.
   // Instead, we use a state as a ref to be reactive.
   const [ref, setRef] = useState<T | null>(null)
 
-  const readValue = useCallback(() => {
+  const readValue = useCallback<() => Size>(() => {
     return {
-      width: ref?.offsetWidth ?? 0,
-      height: ref?.offsetHeight ?? 0,
+      width: ref?.offsetWidth ?? undefined,
+      height: ref?.offsetHeight ?? undefined,
     }
   }, [ref?.offsetHeight, ref?.offsetWidth])
 
-  const [size, setSize] = useState(() => {
+  const [size, setSize] = useState<Size>(() => {
     if (initializeWithValue) {
       return readValue()
     }
-    return { width: 0, height: 0 }
+    return { width: undefined, height: undefined }
   })
 
   // Prevent too many rendering using useCallback
@@ -80,5 +73,12 @@ export function useElementSize<T extends HTMLElement = HTMLDivElement>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref?.offsetHeight, ref?.offsetWidth])
 
-  return [setRef, size]
+  const result = [setRef, size] as UseElementSizeResult
+
+  // Support object destructuring
+  result.ref = result[0]
+  result.width = size.width
+  result.height = size.height
+
+  return result
 }

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
@@ -2,15 +2,25 @@ import { useLocalStorage } from './useLocalStorage'
 
 // Usage
 export default function Component() {
-  const [isDarkTheme, setDarkTheme] = useLocalStorage('darkTheme', true)
-
-  const toggleTheme = () => {
-    setDarkTheme((prevValue: boolean) => !prevValue)
-  }
+  const [value, setValue] = useLocalStorage('test-key', 0)
 
   return (
-    <button onClick={toggleTheme}>
-      {`The current theme is ${isDarkTheme ? `dark` : `light`}`}
-    </button>
+    <div>
+      <p>Count: {value}</p>
+      <button
+        onClick={() => {
+          setValue((x: number) => x + 1)
+        }}
+      >
+        Increment
+      </button>
+      <button
+        onClick={() => {
+          setValue((x: number) => x - 1)
+        }}
+      >
+        Decrement
+      </button>
+    </div>
   )
 }

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.md
@@ -3,7 +3,7 @@ This hook is used in the same way as useState except that you must pass the stor
 
 You can also pass an optional third parameter to use a custom serializer/deserializer.
 
-**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`, it will initialize in SSR with the initial value.
 
 ### Related hooks
 

--- a/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
@@ -2,9 +2,9 @@ import { useState } from 'react'
 
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
-type UseMediaQueryOptions<InitializeWithValue extends boolean | undefined> = {
+type UseMediaQueryOptions = {
   defaultValue?: boolean
-  initializeWithValue: InitializeWithValue
+  initializeWithValue?: boolean
 }
 
 const IS_SERVER = typeof window === 'undefined'
@@ -22,23 +22,17 @@ const IS_SERVER = typeof window === 'undefined'
  * // Use `isSmallScreen` to conditionally apply styles or logic based on the screen size.
  */
 export function useMediaQuery(query: string, defaultValue: boolean): boolean // defaultValue should be false by default
-// SSR version of useMediaQuery.
 export function useMediaQuery(
   query: string,
-  options: UseMediaQueryOptions<false>,
-): boolean | undefined
-// CSR version of useMediaQuery.
-export function useMediaQuery(
-  query: string,
-  options?: Partial<UseMediaQueryOptions<true>>,
+  options?: UseMediaQueryOptions,
 ): boolean
 /**
  * Custom hook for tracking the state of a media query.
  * @param {string} query - The media query to track.
  * @param {boolean | ?UseMediaQueryOptions} [options] - The default value to return if the hook is being run on the server (default is `false`).
  * @param {?boolean} [options.defaultValue] - The default value to return if the hook is being run on the server (default is `false`).
- * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the media query. In SSR, you should set it to `false`, returning `undefined`  or `options.defaultValue` initially.
- * @returns {boolean | undefined} The current state of the media query (true if the query matches, false otherwise).
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading the media query. In SSR, you should set it to `false`, returning `options.defaultValue` or `false` initially.
+ * @returns {boolean} The current state of the media query (true if the query matches, false otherwise).
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-media-query)
  * @see [MDN Match Media](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)
  * @example
@@ -47,19 +41,15 @@ export function useMediaQuery(
  */
 export function useMediaQuery(
   query: string,
-  options?: boolean | Partial<UseMediaQueryOptions<boolean>>,
-): boolean | undefined {
+  options?: boolean | UseMediaQueryOptions,
+): boolean {
   // TODO: Refactor this code after the deprecated signature has been removed.
   const defaultValue =
     typeof options === 'boolean' ? options : options?.defaultValue ?? false
-  let initializeWithValue =
+  const initializeWithValue =
     typeof options === 'boolean'
       ? undefined
       : options?.initializeWithValue ?? undefined
-
-  if (IS_SERVER) {
-    initializeWithValue = false
-  }
 
   const [matches, setMatches] = useState<boolean>(() => {
     if (initializeWithValue) {
@@ -69,10 +59,10 @@ export function useMediaQuery(
   })
 
   const getMatches = (query: string): boolean => {
-    if (typeof window !== 'undefined') {
-      return window.matchMedia(query).matches
+    if (IS_SERVER) {
+      return defaultValue
     }
-    return defaultValue
+    return window.matchMedia(query).matches
   }
 
   /** Handles the change event of the media query. */

--- a/packages/usehooks-ts/src/useScreen/useScreen.demo.tsx
+++ b/packages/usehooks-ts/src/useScreen/useScreen.demo.tsx
@@ -1,14 +1,12 @@
 import { useScreen } from './useScreen'
 
 export default function Component() {
-  const screen = useScreen()
+  const { width = 0, height = 0 } = useScreen()
 
   return (
     <div>
       The current window dimensions are:{' '}
-      <code>
-        {JSON.stringify({ width: screen?.width, height: screen?.height })}
-      </code>
+      <code>{JSON.stringify({ width, height })}</code>
     </div>
   )
 }

--- a/packages/usehooks-ts/src/useScreen/useScreen.md
+++ b/packages/usehooks-ts/src/useScreen/useScreen.md
@@ -1,3 +1,3 @@
 Easily retrieve `window.screen` object with this Hook React which also works onResize.
 
-**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`, it will initialize with `undefined`.

--- a/packages/usehooks-ts/src/useScreen/useScreen.ts
+++ b/packages/usehooks-ts/src/useScreen/useScreen.ts
@@ -43,7 +43,6 @@ export function useScreen(
     setScreen(window.screen)
   }
 
-  // TODO: Prefer incoming useResizeObserver hook
   useEventListener('resize', handleSize)
 
   // Set size at the first client-side load

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.md
@@ -2,7 +2,7 @@ Persist the state with session storage so that it remains after a page refresh. 
 
 You can also pass an optional third parameter to use a custom serializer/deserializer.
 
-**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`.
+**Note**: If you use this hook in an SSR context, set the `initializeWithValue` option to `false`, it will initialize in SSR with the initial value.
 
 Related hooks:
 

--- a/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
+++ b/packages/usehooks-ts/src/useTernaryDarkMode/useTernaryDarkMode.ts
@@ -8,27 +8,24 @@ const LOCAL_STORAGE_KEY = 'usehooks-ts-ternary-dark-mode'
 
 export type TernaryDarkMode = 'system' | 'dark' | 'light'
 
-type TernaryDarkModeOptions<InitializeWithValue extends boolean | undefined> = {
+type TernaryDarkModeOptions = {
   defaultValue?: TernaryDarkMode
   localStorageKey?: string
-  initializeWithValue: InitializeWithValue
+  initializeWithValue?: boolean
 }
 
-type ReturnedMethods = {
-  setTernaryDarkMode: Dispatch<SetStateAction<TernaryDarkMode>>
-  toggleTernaryDarkMode: () => void
-}
-
-type ReturnedValues = {
+type TernaryDarkModeResult = {
   isDarkMode: boolean
   ternaryDarkMode: TernaryDarkMode
+  setTernaryDarkMode: Dispatch<SetStateAction<TernaryDarkMode>>
+  toggleTernaryDarkMode: () => void
 }
 
 /**
  * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
  * @deprecated this useTernaryDarkMode's signature is deprecated, it now accepts an options object instead of multiple parameters.
  * @param {string} localStorageKey - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
- * @returns {ReturnedMethods & ReturnedValues} An object containing the dark mode state and helper functions.
+ * @returns {TernaryDarkModeResult} An object containing the dark mode state and helper functions.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
  * @example
  * const { isDarkMode, ternaryDarkMode, setTernaryDarkMode, toggleTernaryDarkMode } = useTernaryDarkMode('my-key');
@@ -36,33 +33,27 @@ type ReturnedValues = {
  */
 export function useTernaryDarkMode(
   localStorageKey: string,
-): ReturnedMethods & ReturnedValues
+): TernaryDarkModeResult
 
-// SSR version of useTernaryDarkMode.
 export function useTernaryDarkMode(
-  options: TernaryDarkModeOptions<false>,
-): ReturnedMethods & Partial<ReturnedValues>
-
-// CSR version of useTernaryDarkMode.
-export function useTernaryDarkMode(
-  options?: Partial<TernaryDarkModeOptions<true>>,
-): ReturnedMethods & ReturnedValues
+  options?: TernaryDarkModeOptions,
+): TernaryDarkModeResult
 
 /**
  * Custom hook for managing ternary (system, dark, light) dark mode with local storage support.
  * @param {?TernaryDarkModeOptions | string} [options] - Options or the local storage key for the hook.
  * @param {?string} [options.localStorageKey] - The key for storing dark mode preference in local storage (default is `'usehooks-ts-ternary-dark-mode'`).
  * @param {?TernaryDarkMode} [options.defaultValue] - The default value for the dark mode (default is `'system'`).
- * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading `localStorage`. In SSR, you should set it to `false`, returning `undefined` initially.
- * @returns {ReturnedMethods & Partial<ReturnedValues>} An object containing the dark mode state and helper functions.
+ * @param {?boolean} [options.initializeWithValue] - If `true` (default), the hook will initialize reading `localStorage`. In SSR, you should set it to `false`, returning default values initially.
+ * @returns {TernaryDarkModeResult} An object containing the dark mode state and helper functions.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-ternary-dark-mode)
  * @example
  * const { isDarkMode, ternaryDarkMode, setTernaryDarkMode, toggleTernaryDarkMode } = useTernaryDarkMode({ defaultValue: 'dark' });
  * // Access and use the dark mode state and provided helper functions.
  */
 export function useTernaryDarkMode(
-  options?: string | Partial<TernaryDarkModeOptions<boolean>>,
-): ReturnedMethods & Partial<ReturnedValues> {
+  options?: string | TernaryDarkModeOptions,
+): TernaryDarkModeResult {
   // TODO: Refactor this code after the deprecated signature has been removed.
   const defaultValue =
     typeof options === 'string' ? 'system' : options?.defaultValue ?? 'system'
@@ -75,7 +66,7 @@ export function useTernaryDarkMode(
       ? undefined
       : options?.initializeWithValue ?? undefined
 
-  const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY)
+  const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY, { initializeWithValue })
   const [mode, setMode] = useLocalStorage(localStorageKey, defaultValue, {
     initializeWithValue,
   })

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.demo.tsx
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.demo.tsx
@@ -1,11 +1,12 @@
 import { useWindowSize } from './useWindowSize'
 
 export default function Component() {
-  const size = useWindowSize()
+  const { width = 0, height = 0 } = useWindowSize()
 
   return (
     <div>
-      The current window dimensions are: <code>{JSON.stringify(size)}</code>
+      The current window dimensions are:{' '}
+      <code>{JSON.stringify({ width, height })}</code>
     </div>
   )
 }

--- a/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
+++ b/packages/usehooks-ts/src/useWindowSize/useWindowSize.ts
@@ -3,9 +3,9 @@ import { useState } from 'react'
 import { useEventListener } from '../useEventListener'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
-interface WindowSize {
-  width: number
-  height: number
+interface WindowSize<T extends number | undefined = number | undefined> {
+  width: T
+  height: T
 }
 
 type UseWindowSizeOptions<InitializeWithValue extends boolean | undefined> = {
@@ -15,13 +15,11 @@ type UseWindowSizeOptions<InitializeWithValue extends boolean | undefined> = {
 const IS_SERVER = typeof window === 'undefined'
 
 // SSR version of useWindowSize.
-export function useWindowSize(
-  options: UseWindowSizeOptions<false>,
-): WindowSize | undefined
+export function useWindowSize(options: UseWindowSizeOptions<false>): WindowSize
 // CSR version of useWindowSize.
 export function useWindowSize(
   options?: Partial<UseWindowSizeOptions<true>>,
-): WindowSize
+): WindowSize<number>
 /**
  * Custom hook that tracks the size of the window.
  * @param {?UseWindowSizeOptions} [options] - The options for customizing the behavior of the hook (optional).
@@ -37,23 +35,26 @@ export function useWindowSize(
  */
 export function useWindowSize(
   options: Partial<UseWindowSizeOptions<boolean>> = {},
-): WindowSize | undefined {
+): WindowSize | WindowSize<number> {
   let { initializeWithValue = true } = options
   if (IS_SERVER) {
     initializeWithValue = false
   }
 
-  const [windowSize, setWindowSize] = useState(() => {
+  const [windowSize, setWindowSize] = useState<WindowSize>(() => {
     if (initializeWithValue) {
       return {
         width: window.innerWidth,
         height: window.innerHeight,
       }
     }
-    return undefined
+    return {
+      width: undefined,
+      height: undefined,
+    }
   })
 
-  const handleSize = () => {
+  function handleSize() {
     setWindowSize({
       width: window.innerWidth,
       height: window.innerHeight,
@@ -66,7 +67,6 @@ export function useWindowSize(
   // Set size at the first client-side load
   useIsomorphicLayoutEffect(() => {
     handleSize()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return windowSize


### PR DESCRIPTION
This PR follows #451 and updates a bit the behavior;
Instead of returning `undefined` on the server, it fallbacks to initial or default value instead when possible (eg: `useLocalStorage`).

For hooks like `useWindowsSize`, it now returns `{ width: number | undefined; height: number | undefined }` which can be initialized with default values like this: 

```ts
const { width = 0, height = 0 } = useWindowSize({ initializeWithValue: false })
```

Nothing should change for CSR context.