### PR TITLE
🗑️ Deprecated `useEffectOnce`, `useIsFirstRender` and `useUpdateEffect`

### DIFF
--- a/.changeset/proud-pens-shave.md
+++ b/.changeset/proud-pens-shave.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+Deprecated `useEffectOnce`, `useIsFirstRender` and `useUpdateEffect`

--- a/packages/usehooks-ts/src/useEffectOnce/useEffectOnce.md
+++ b/packages/usehooks-ts/src/useEffectOnce/useEffectOnce.md
@@ -1,7 +1,1 @@
-Just modified version of `useEffect` that's executed only one time, at the mounting time.
-
-See also:
-
-- [`useUpdateEffect()`](/react-hook/use-update-effect): Inverse of `useEffectOnce()`
-- [`useIsFirstRender()`](/react-hook/use-is-first-render): Return a `boolean`
-- [`useIsMounted()`](/react-hook/use-is-mounted): Callback function to avoid Promise execution after component un-mount
+This hook is **deprecated** and will be dropped in the next major release because it can be misleading. It doesn't actually perform its action only once, but rather during mounting. Given its limited logic, it's better to use React's API directly without adding unnecessary abstraction.

--- a/packages/usehooks-ts/src/useEffectOnce/useEffectOnce.ts
+++ b/packages/usehooks-ts/src/useEffectOnce/useEffectOnce.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import type { EffectCallback } from 'react'
 
 /**
+ * @deprecated - Don't use this hook, it'll be removed in the next major version.
  * A hook that runs an effect only once (at mount).
  * @param {EffectCallback} effect - The effect to run.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-effect-once)

--- a/packages/usehooks-ts/src/useIsFirstRender/useIsFirstRender.md
+++ b/packages/usehooks-ts/src/useIsFirstRender/useIsFirstRender.md
@@ -1,10 +1,1 @@
-Simple React hook that return a boolean;
-
-- True at the mount time
-- Then always false
-
-See also:
-
-- [`useEffectOnce()`](/react-hook/use-effect-once): A modified `useEffect()` executed only on mount
-- [`useUpdateEffect()`](/react-hook/use-update-effect): A modified `useEffect()` executed only on updates (skip first render)
-- [`useIsMounted()`](/react-hook/use-is-mounted): Callback function to avoid Promise execution after component un-mount
+This hook is **deprecated** and will be dropped in a future major release. `useEffect` is designed for synchronization. React 18 emphasizes this concept by rendering components twice in strict mode to highlight improper usage. Attempting to skip the first render is considered a hack.

--- a/packages/usehooks-ts/src/useIsFirstRender/useIsFirstRender.ts
+++ b/packages/usehooks-ts/src/useIsFirstRender/useIsFirstRender.ts
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 
 /**
+ * @deprecated - Don't use this hook, it's an anti-pattern.
  * Custom hook for determining if the component is rendering for the first time.
  * @returns {boolean} A boolean value indicating whether the component is rendering for the first time.
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-is-first-render)

--- a/packages/usehooks-ts/src/useUpdateEffect/useUpdateEffect.md
+++ b/packages/usehooks-ts/src/useUpdateEffect/useUpdateEffect.md
@@ -1,7 +1,1 @@
-Just modified version of `useEffect` that is skipping the first render.
-
-See also:
-
-- [`useEffectOnce()`](/react-hook/use-effect-once): Inverse of `useUpdateEffect()`
-- [`useIsFirstRender()`](/react-hook/use-is-first-render): Return a `boolean`
-- [`useIsMounted()`](/react-hook/use-is-mounted): Callback function to avoid Promise execution after component un-mount
+This hook is **deprecated** and will be dropped in a future major release. `useEffect` is designed for synchronization. React 18 emphasizes this concept by rendering components twice in strict mode to highlight improper usage. Attempting to skip the first render is considered a hack.

--- a/packages/usehooks-ts/src/useUpdateEffect/useUpdateEffect.ts
+++ b/packages/usehooks-ts/src/useUpdateEffect/useUpdateEffect.ts
@@ -5,6 +5,7 @@ import type { DependencyList, EffectCallback } from 'react'
 import { useIsFirstRender } from '../useIsFirstRender'
 
 /**
+ * @deprecated - Don't use this hook, it's an anti-pattern.
  * Custom hook that runs an effect only on updates (not on the initial render).
  * @param {EffectCallback} effect - The function to run as the effect.
  * @param {DependencyList} [deps] - An optional array of dependencies for the effect.

--- a/scripts/updateReadme.mjs
+++ b/scripts/updateReadme.mjs
@@ -17,6 +17,9 @@ const excludeHooks = [
   'useImageOnLoad', // @deprecated
   'useElementSize', // @deprecated
   'useFetch', // @deprecated
+  'useUpdateEffect', // @deprecated
+  'useEffectOnce', // @deprecated
+  'useIsFirstRender', // @deprecated
 ]
 
 const markdown = fs

--- a/scripts/updateTestingIssue.mjs
+++ b/scripts/updateTestingIssue.mjs
@@ -12,6 +12,9 @@ const excludeHooks = [
   'useImageOnLoad', // @deprecated
   'useElementSize', // @deprecated
   'useFetch', // @deprecated
+  'useUpdateEffect', // @deprecated
+  'useEffectOnce', // @deprecated
+  'useIsFirstRender', // @deprecated
   'useIsomorphicLayoutEffect', // Combination of useLayoutEffect and useEffect without custom logic
 ]
 


### PR DESCRIPTION
These hooks are deprecated and will be dropped in a future major release. While they may seem convenient, their behavior can be misleading or can encourage bad practices (component lifecycle mindset). Instead, opt for useEffect for synchronization, as React 18 emphasizes its importance by rendering components twice in strict mode to highlight improper usage. Prefer using React's API directly.

Fixes: #389 