### PR TITLE
ci: update `pnpm/action-setup` to v3 for `node-20` changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build and test
 on:
   push:
     branches:
-      - '**'
+      - 'master'
   pull_request:
 
 env:


### PR DESCRIPTION
`pnpm/action-setup` has been updated to `v3` which now uses `node-20` actions as `node-16` actions are deprecated.
