### PR TITLE
feature: add a reset function to useLocalStorage

### DIFF
--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
@@ -1,7 +1,7 @@
 import { useLocalStorage } from './useLocalStorage'
 
 export default function Component() {
-  const [value, setValue] = useLocalStorage('test-key', 0)
+  const [value, setValue, reset] = useLocalStorage('test-key', 0)
 
   return (
     <div>
@@ -19,6 +19,13 @@ export default function Component() {
         }}
       >
         Decrement
+      </button>
+      <button
+        onClick={() => {
+          reset()
+        }}
+      >
+        Reset
       </button>
     </div>
   )

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -128,6 +128,49 @@ describe('useLocalStorage()', () => {
     expect(window.localStorage.getItem('count')).toEqual('5')
   })
 
+  it('Reset the state with static initial value', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 2))
+
+    act(() => {
+      const setState = result.current[1]
+      const reset = result.current[2]
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+      setState(prev => prev + 1)
+      reset()
+    })
+
+    expect(result.current[0]).toBe(2)
+    expect(window.localStorage.getItem('count')).toEqual('2')
+  })
+
+  it('Reset the state with initial value as a function', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('count', () => ({
+        id: 1,
+        name: 'Joe',
+      })),
+    )
+
+    act(() => {
+      const setState = result.current[1]
+      const reset = result.current[2]
+      setState({
+        id: 2,
+        name: 'Jane',
+      })
+      reset()
+    })
+
+    expect(result.current[0]).toEqual({
+      id: 1,
+      name: 'Joe',
+    })
+    expect(window.localStorage.getItem('count')).toEqual(
+      '{"id":1,"name":"Joe"}',
+    )
+  })
+
   it('[Event] Update one hook updates the others', () => {
     const initialValues: [string, unknown] = ['key', 'initial']
     const { result: A } = renderHook(() => useLocalStorage(...initialValues))


### PR DESCRIPTION
Added a `reset` function to `useLocalStorage`. I want to reset the state to the initial value. I know this is feasible without this change but thought it would be a nice addition.

Up to you guys if you want to merge it.