### PR TITLE
Fix setMatches hook in useMediaQuery by defining getMatches before use

### DIFF
--- a/.changeset/real-foxes-fold.md
+++ b/.changeset/real-foxes-fold.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": major
+---
+
+Fix setMatches hook in useMediaQuery by defining getMatches before use

--- a/.changeset/real-foxes-fold.md
+++ b/.changeset/real-foxes-fold.md
@@ -1,5 +1,5 @@
 ---
-"usehooks-ts": major
+"usehooks-ts": patch
 ---
 
 Fix setMatches hook in useMediaQuery by defining getMatches before use

--- a/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
@@ -51,19 +51,19 @@ export function useMediaQuery(
       ? undefined
       : options?.initializeWithValue ?? undefined
 
-  const [matches, setMatches] = useState<boolean>(() => {
-    if (initializeWithValue) {
-      return getMatches(query)
-    }
-    return defaultValue
-  })
-
   const getMatches = (query: string): boolean => {
     if (IS_SERVER) {
       return defaultValue
     }
     return window.matchMedia(query).matches
   }
+
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (initializeWithValue) {
+      return getMatches(query)
+    }
+    return defaultValue
+  })
 
   /** Handles the change event of the media query. */
   function handleChange() {


### PR DESCRIPTION
This PR fixes the setMatches hook in useMediaQuery in version 2.14.0. 

If initializeWithValue is set to true getMatches is called before it is defined. This issues comes with v. usehooks-ts@2.14.0
https://github.com/juliencrn/usehooks-ts/commit/4a9fc884c3e913f7d4c78739d2e4184ece2c4d72

