### PR TITLE
chore: delete extra `.d.ts` file to fix duplicate declarations

### DIFF
--- a/packages/usehooks-ts/package.json
+++ b/packages/usehooks-ts/package.json
@@ -23,7 +23,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && rm ./dist/index.d.mts",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
As we support both `esm` and `cjs` versions, `tsup` generates `.js` and `.mjs` files along with `.d.ts` and `.d.mts` files. Even though only one `.d.ts` file is needed. This leads to duplicated entries in the auto complete.
![image](https://github.com/juliencrn/usehooks-ts/assets/130567419/d2c41342-2dcd-4855-b59a-622713a72a39)

I haven't found any way to disable this behaviour and have one `.d.ts` file for multiple output formats. So I have added an extra `rm` in build command to fix the issue for now. I will make an issue in `tsup`'s repo about this. After a fix is found, I will add another PR addressing this.