### PR TITLE
fix useResizeObserver initialSize mutation

### DIFF
--- a/.changeset/gold-spiders-invent.md
+++ b/.changeset/gold-spiders-invent.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+fix `useResizeObserver` initialSize mutation (#504 from @iuriiiurevich)

--- a/packages/usehooks-ts/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/usehooks-ts/src/useResizeObserver/useResizeObserver.ts
@@ -57,7 +57,7 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>(
   const { ref, box = 'content-box' } = options
   const [{ width, height }, setSize] = useState<Size>(initialSize)
   const isMounted = useIsMounted()
-  const previousSize = useRef<Size>(initialSize)
+  const previousSize = useRef<Size>({ ...initialSize })
   const onResize = useRef<ResizeHandler | undefined>(undefined)
   onResize.current = options?.onResize
 


### PR DESCRIPTION
This PR fixes a mutation of the initialSize, due to which the hook may not work correctly when there is two or more instances of it.