### PR TITLE
Resolve warning when using useScrollLock in nextJS

### DIFF
--- a/.changeset/fresh-pillows-cross.md
+++ b/.changeset/fresh-pillows-cross.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+Resolve warning when using useScrollLock in an SSR environment

--- a/packages/usehooks-ts/src/useScrollLock/useScrollLock.ts
+++ b/packages/usehooks-ts/src/useScrollLock/useScrollLock.ts
@@ -1,4 +1,6 @@
-import { useLayoutEffect, useRef } from 'react'
+import { useRef } from 'react'
+
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
 interface UseScrollLockOptions {
   autoLock: boolean
@@ -80,7 +82,7 @@ export function useScrollLock(
     }
   }
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (IS_SERVER) return
 
     if (lockTarget) {


### PR DESCRIPTION
Hello again, I just happened to notice after using this hook that we are getting the following error on nextJS:

>Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

I believe using this own repo's `useIsomorphicLayoutEffect` should resolve that warning and not cause any issues for folks not using nextJS.