### PR TITLE
Fix a link in migration docs

### DIFF
--- a/.changeset/lazy-crews-chew.md
+++ b/.changeset/lazy-crews-chew.md
@@ -1,0 +1,5 @@
+---
+"www": patch
+---
+
+Fix a link in migration docs

--- a/apps/www/src/app/(docs)/migrate-to-v3/page.tsx
+++ b/apps/www/src/app/(docs)/migrate-to-v3/page.tsx
@@ -112,7 +112,7 @@ export default async function MigrateToV3Page() {
             </components.a>
           </components.li>
           <components.li>
-            <components.a href="/react-hook/use-dark-mode">
+            <components.a href="/react-hook/use-ternary-dark-mode">
               <components.code>useTernaryDarkMode</components.code>
             </components.a>
           </components.li>


### PR DESCRIPTION
This pull request fixes a link in the migration to v3 documentation for `useTernaryDarkMode`.