### PR TITLE
Use timeout enhancement

### DIFF
--- a/.changeset/plenty-trainers-obey.md
+++ b/.changeset/plenty-trainers-obey.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": minor
+---
+
+Update useTimeout with utility functions and states

--- a/packages/usehooks-ts/src/useTimeout/useTimeout.test.ts
+++ b/packages/usehooks-ts/src/useTimeout/useTimeout.test.ts
@@ -3,14 +3,132 @@ import { act, renderHook } from '@testing-library/react'
 import { useTimeout } from './useTimeout'
 
 describe('useTimeout()', () => {
-  it('should call the callback after 1 min', () => {
+  beforeEach(() => {
     vitest.useFakeTimers()
+  })
 
+  afterEach(() => {
+    vitest.useRealTimers()
+  })
+
+  it('should call the callback after 1 min', () => {
     const delay = 60000
     const callback = vitest.fn()
 
-    renderHook(() => {
-      useTimeout(callback, delay)
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(false)
+    expect(result.current.isRunning).toBe(true)
+    expect(result.current.isPaused).toBe(false)
+
+    act(() => {
+      vitest.advanceTimersByTime(delay)
+    })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(result.current.isStopped).toBe(true)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(false)
+  })
+
+  it('should not do anything if "delay" is null', () => {
+    const delay = null
+    const callback = vitest.fn()
+
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(true)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(false)
+
+    act(() => {
+      vitest.runAllTimers()
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('should pause the timeout and not call the callback', () => {
+    const delay = 60000
+    const callback = vitest.fn()
+
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    act(() => {
+      vitest.advanceTimersByTime(1)
+    })
+
+    act(() => {
+      result.current.pause()
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(false)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(true)
+
+    act(() => {
+      vitest.advanceTimersByTime(delay)
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(false)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(true)
+  })
+
+  it('should start a paused timeout and call the callback', () => {
+    const delay = 60000
+    const timeIncrement = delay / 2
+    const callback = vitest.fn()
+
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    act(() => {
+      vitest.advanceTimersByTime(timeIncrement)
+    })
+
+    act(() => {
+      result.current.pause()
+    })
+
+    act(() => {
+      vitest.advanceTimersByTime(timeIncrement)
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(false)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(true)
+
+    act(() => {
+      result.current.start()
+    })
+
+    act(() => {
+      vitest.advanceTimersByTime(timeIncrement)
+    })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(result.current.isStopped).toBe(true)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(false)
+  })
+
+  it('should stop the timeout and not call the callback', () => {
+    const delay = 60000
+    const callback = vitest.fn()
+
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    act(() => {
+      vitest.advanceTimersByTime(1)
+    })
+
+    act(() => {
+      result.current.stop()
     })
 
     expect(callback).not.toHaveBeenCalled()
@@ -19,25 +137,60 @@ describe('useTimeout()', () => {
       vitest.advanceTimersByTime(delay)
     })
 
-    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).not.toHaveBeenCalled()
+    expect(result.current.isStopped).toBe(true)
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isPaused).toBe(false)
   })
 
-  it('should not do anything if "delay" is null', () => {
-    vitest.useFakeTimers()
-
-    const delay = null
+  it('should reset a running timeout and call the callback after new timeout finishes', () => {
+    const delay = 60000
+    const timeIncrement = delay / 2
     const callback = vitest.fn()
 
-    renderHook(() => {
-      useTimeout(callback, delay)
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    act(() => {
+      vitest.advanceTimersByTime(timeIncrement)
+    })
+
+    act(() => {
+      result.current.reset()
+    })
+
+    act(() => {
+      vitest.advanceTimersByTime(timeIncrement)
     })
 
     expect(callback).not.toHaveBeenCalled()
 
     act(() => {
-      vitest.runAllTimers()
+      vitest.advanceTimersByTime(timeIncrement)
     })
 
-    expect(callback).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  it('should reset a finished timeout and end up calling the callback 2 times in total', () => {
+    const delay = 60000
+    const callback = vitest.fn()
+
+    const { result } = renderHook(() => useTimeout(callback, delay))
+
+    act(() => {
+      vitest.advanceTimersByTime(delay)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.reset()
+    })
+
+    act(() => {
+      vitest.advanceTimersByTime(delay)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/usehooks-ts/src/useTimeout/useTimeout.ts
+++ b/packages/usehooks-ts/src/useTimeout/useTimeout.ts
@@ -1,12 +1,30 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
+/**
+ * The return type of the useTimeout hook.
+ */
+type UseTimeoutReturn = {
+  /** A boolean indicating if timeout is currently running. */
+  isRunning: boolean
+  /** A boolean indicating if timeout is currently paused. */
+  isPaused: boolean
+  /** A boolean indicating if timeout is currently stopped or finished. */
+  isStopped: boolean
+  /** Function to start the timeout. */
+  start: () => void
+  /** Function to pause a running timeout. */
+  pause: () => void
+  /** Function to stop a running timeout. */
+  stop: () => void
+  /** Function to reset a running or stopped timeout. */
+  reset: () => void
+}
 
 /**
  * Custom hook that handles timeouts in React components.
  * @param {() => void} callback - The function to be executed when the timeout elapses.
  * @param {number | null} delay - The duration (in milliseconds) for the timeout. Set to `null` to clear the timeout.
- * @returns {void} This hook does not return anything.
+ * @returns {UseTimeoutReturn} An object containing the timeout state and utility functions to pause, stop, start or reset the timeout.
  * @public
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-timeout)
  * @see [MDN setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
@@ -18,28 +36,99 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
  * }, 1000); // Set a timeout of 1000 milliseconds (1 second)
  * ```
  */
-export function useTimeout(callback: () => void, delay: number | null): void {
+export function useTimeout(
+  callback: () => void,
+  delay: number | null,
+): UseTimeoutReturn {
   const savedCallback = useRef(callback)
+  const internalDelayRef = useRef<number | null>(null)
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
-  // Remember the latest callback if it changes.
-  useIsomorphicLayoutEffect(() => {
+  // There are two timestamp states:
+  // processStartTime - kicks off the render which will schedule the timeout
+  // actualStartTime - more accurate timeout start time as it's set in the same render phase as timeout
+  const [processStartTime, setProcessStartTime] = useState<number | null>(null)
+  const [actualStartTime, setActualStartTime] = useState<number | null>(null)
+  const [timeElapsed, setTimeElapsed] = useState<number>(0)
+
+  const cleanUp = useCallback((fullCleanUp?: boolean) => {
+    if (timeoutRef.current) {
+      // Clear timeout
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = undefined
+
+      // Reset both timestamps
+      setProcessStartTime(null)
+      setActualStartTime(null)
+    }
+
+    // Clear elapsed time for a full clean up
+    if (fullCleanUp) setTimeElapsed(0)
+  }, [])
+
+  const start = useCallback(() => {
+    const currentDelay = internalDelayRef.current
+    // Don't run if no delay is specified or a timeout is already running
+    // Note: 0 is a valid value for delay
+    if (timeoutRef.current ?? (!currentDelay && currentDelay !== 0)) return
+
+    setProcessStartTime(Date.now())
+  }, [])
+
+  const pause = useCallback(() => {
+    if (!timeoutRef.current || !actualStartTime) return
+
+    // Save the amount of time that has elapsed since the timeout started
+    setTimeElapsed(prev => prev + Date.now() - actualStartTime)
+    // Soft clean up to keep elapsed time
+    cleanUp()
+  }, [actualStartTime, cleanUp])
+
+  const stop = useCallback(() => {
+    cleanUp(true)
+  }, [cleanUp])
+
+  const reset = useCallback(() => {
+    stop()
+    start()
+  }, [stop, start])
+
+  // Remember the latest callback if it changes
+  useEffect(() => {
     savedCallback.current = callback
   }, [callback])
 
-  // Set up the timeout.
+  // Update internal delay ref and reset the timeout when delay prop changes
   useEffect(() => {
-    // Don't schedule if no delay is specified.
-    // Note: 0 is a valid value for delay.
-    if (!delay && delay !== 0) {
-      return
+    if (internalDelayRef.current !== delay) {
+      internalDelayRef.current = delay
+      reset()
     }
+  }, [delay, reset])
 
-    const id = setTimeout(() => {
+  useEffect(() => {
+    // Don't schedule if there's no start time or delay is not specified
+    if (!processStartTime || internalDelayRef.current === null) return
+
+    // Set up the timeout
+    timeoutRef.current = setTimeout(() => {
       savedCallback.current()
-    }, delay)
+      // Clean everything up after callback is called
+      cleanUp(true)
+    }, internalDelayRef.current - timeElapsed)
 
-    return () => {
-      clearTimeout(id)
-    }
-  }, [delay])
+    setActualStartTime(Date.now())
+
+    return cleanUp
+  }, [processStartTime, timeElapsed, cleanUp])
+
+  return {
+    isRunning: !!timeoutRef.current,
+    isPaused: !timeoutRef.current && !!timeElapsed,
+    isStopped: !timeoutRef.current && !timeElapsed,
+    start,
+    pause,
+    stop,
+    reset,
+  }
 }


### PR DESCRIPTION
This pull request enhances the `useTimeout` hook (based on [this](https://github.com/juliencrn/usehooks-ts/issues/311) request) by adding a few utility functions and states (and tests).

New states:
- `isRunning`
- `isPaused`
- `isStopped`

New helper functions:
- `pause()`
- `start()`
- `stop()`
- `reset()`