### PR TITLE
fix: update useDarkMode to not reset with OS value on every refresh

### DIFF
--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
@@ -1,4 +1,3 @@
-import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useLocalStorage } from '../useLocalStorage'
 import { useMediaQuery } from '../useMediaQuery'
 
@@ -66,13 +65,6 @@ export function useDarkMode(options: DarkModeOptions = {}): DarkModeReturn {
     defaultValue ?? isDarkOS ?? false,
     { initializeWithValue },
   )
-
-  // Update darkMode if os prefers changes
-  useIsomorphicLayoutEffect(() => {
-    if (isDarkOS !== isDarkMode) {
-      setDarkMode(isDarkOS)
-    }
-  }, [isDarkOS])
 
   return {
     isDarkMode,

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
@@ -145,7 +145,9 @@ export function useLocalStorage<T>(
   })
 
   useEffect(() => {
-    setStoredValue(readValue())
+    const value = readValue()
+    setValue(value)
+    setStoredValue(value)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key])
 


### PR DESCRIPTION
Fixes https://github.com/juliencrn/usehooks-ts/issues/512

This PR does two things:

### 1. Update useLocalStorage save initial value

The way things are now, useLocalStorage does not correctly represents the value in the `localStorage`. It returns a default value even if the `key` doesn't exist there yet and does not create it, meaning it returns a value that is not necessarily the truth (should be `undefined`. This causes a problem in `useDarkMode` (and probably other hooks).

The PR updates the hook to actually save the key/value in `localStorage` when the hook is called, preserving the hook's initial funcionality.

### 2. Update `useDarkMode` to not reset with OS value on every refresh

Removes the `useIsomorphicLayoutEffect` because it's unnecessary. The value `isDarkMode` will always be correctly set.