### PR TITLE
fix: update the minmium supported node version to 18.17.0 for development

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Here is a quick guide to doing code contributions to the library.
 
 1. Make sure to have the right dependencies up-to-date:
 
-   - `"node": ">=16.15"`
+   - `"node": ">=18.17.0"`
    - `"pnpm": "^8"`
 
 2. Fork and clone the repo to your local machine:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "zx": "^7.2.3"
   },
   "engines": {
-    "node": ">=16.15.0"
+    "node": ">=18.17.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If someone wants to contribute code to the project, and they follow the README's guidelines for local development, an error was occurred while run the `pnpm build` command in the repository root directory:
```
www:build: /Users/<username>/usehooks-ts/apps/www
www:build: You are using Node.js 16.15.0. For Next.js, Node.js version >= v18.17.0 is required.
```
Update the minimum supported node version to make people smoothly run all code and preview the document locally.