### PR TITLE
Add remove function to `useLocalStorage` and `useSessionStorage`

### DIFF
--- a/.changeset/wet-mayflies-build.md
+++ b/.changeset/wet-mayflies-build.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": minor
+---
+
+Add remove function to useLocalStorage and useSessionStorage

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.demo.tsx
@@ -1,7 +1,7 @@
 import { useLocalStorage } from './useLocalStorage'
 
 export default function Component() {
-  const [value, setValue] = useLocalStorage('test-key', 0)
+  const [value, setValue, removeValue] = useLocalStorage('test-key', 0)
 
   return (
     <div>
@@ -19,6 +19,13 @@ export default function Component() {
         }}
       >
         Decrement
+      </button>
+      <button
+        onClick={() => {
+          removeValue()
+        }}
+      >
+        Reset
       </button>
     </div>
   )

--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -76,6 +76,28 @@ describe('useLocalStorage()', () => {
     expect(window.localStorage.getItem('key')).toBe(JSON.stringify('edited'))
   })
 
+  it('Remove the state removes localStorage key', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState('updated')
+    })
+
+    expect(result.current[0]).toBe('updated')
+    expect(window.localStorage.getItem('key')).toBe(JSON.stringify('updated'))
+
+    act(() => {
+      const removeValue = result.current[2]
+      removeValue()
+    })
+
+    // Expect null as it's a default return if storage key doesn't exist
+    expect(window.localStorage.getItem('key')).toBeNull()
+    // Expect the state to match the default value
+    expect(result.current[0]).toBe('value')
+  })
+
   it('Update the state with undefined', () => {
     const { result } = renderHook(() =>
       useLocalStorage<string | undefined>('key', 'value'),

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.demo.tsx
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.demo.tsx
@@ -1,7 +1,7 @@
 import { useSessionStorage } from './useSessionStorage'
 
 export default function Component() {
-  const [value, setValue] = useSessionStorage('test-key', 0)
+  const [value, setValue, removeValue] = useSessionStorage('test-key', 0)
 
   return (
     <div>
@@ -19,6 +19,13 @@ export default function Component() {
         }}
       >
         Decrement
+      </button>
+      <button
+        onClick={() => {
+          removeValue()
+        }}
+      >
+        Reset
       </button>
     </div>
   )

--- a/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
+++ b/packages/usehooks-ts/src/useSessionStorage/useSessionStorage.test.ts
@@ -78,6 +78,28 @@ describe('useSessionStorage()', () => {
     expect(window.sessionStorage.getItem('key')).toBe(JSON.stringify('edited'))
   })
 
+  it('Remove the state removes sessionStorage key', () => {
+    const { result } = renderHook(() => useSessionStorage('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState('updated')
+    })
+
+    expect(result.current[0]).toBe('updated')
+    expect(window.sessionStorage.getItem('key')).toBe(JSON.stringify('updated'))
+
+    act(() => {
+      const removeValue = result.current[2]
+      removeValue()
+    })
+
+    // Expect null as it's a default return if storage key doesn't exist
+    expect(window.sessionStorage.getItem('key')).toBeNull()
+    // Expect the state to match the default value
+    expect(result.current[0]).toBe('value')
+  })
+
   it('Update the state with undefined', () => {
     const { result } = renderHook(() =>
       useSessionStorage<string | undefined>('keytest', 'value'),


### PR DESCRIPTION
This pull request adds a remove function to both `useLocalStorage` and `useSessionStorage` as there's no way to remove a managed key from the storage once it's been set. the function removes the key from the storage and sets the state to the `initialValue` passed in as a prop. The tests are also added to validate the new function.
It is not a breaking change; it just adds another function to the return tuple.

The discussion with this idea is [here](https://github.com/juliencrn/usehooks-ts/discussions/558)