### PR TITLE
Allow useLocalStorage mutation callbacks to be called in render phase

### DIFF
--- a/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
+++ b/packages/usehooks-ts/src/useLocalStorage/useLocalStorage.test.ts
@@ -208,6 +208,22 @@ describe('useLocalStorage()', () => {
     expect(result.current[1] === originalCallback).toBe(true)
   })
 
+  it('setValue can be called in render phase', () => {
+    const { result } = renderHook(() => {
+      const [value, setValue] = useLocalStorage('count', 1)
+
+      // Adjust state with the recommended approach
+      // cf. https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+      if (value !== 2) {
+        setValue(2)
+      }
+
+      return value
+    })
+
+    expect(result.current).toBe(2)
+  })
+
   it('should use default JSON.stringify and JSON.parse when serializer/deserializer not provided', () => {
     const { result } = renderHook(() => useLocalStorage('key', 'initialValue'))
 


### PR DESCRIPTION
The callbacks returned by `useLocalStorage` are currently "event callbacks" and, therefore, can't be called in the render phase. It is in contradiction with the recommended approach to adjust state (cf. https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) where it should be possible to do:

```tsx
function App() {
  const [lsCount, setLsCount] = useLocalStorage('lsCount', 0);

  if (lsCount === 0) {
    // this should work but fails right now
    setLsCount(1);
  }
[...]
```

This PR removes this limitation.
