### PR TITLE
Supports `undefined` title for `useDocumentTitle`

### DIFF
--- a/packages/usehooks-ts/src/useDocumentTitle/useDocumentTitle.test.ts
+++ b/packages/usehooks-ts/src/useDocumentTitle/useDocumentTitle.test.ts
@@ -29,4 +29,15 @@ describe('useDocumentTitle()', () => {
     unmount()
     expect(window.document.title).toEqual('updated')
   })
+
+  it('should unset title on provide `undefined` title', () => {
+    window.document.title = 'initial'
+    const { rerender } = renderHook(useDocumentTitle)
+    rerender('updated')
+    expect(window.document.title).toEqual('updated')
+    rerender('updated again')
+    expect(window.document.title).toEqual('updated again')
+    rerender(undefined)
+    expect(window.document.title).toEqual('initial')
+  })
 })

--- a/packages/usehooks-ts/src/useDocumentTitle/useDocumentTitle.ts
+++ b/packages/usehooks-ts/src/useDocumentTitle/useDocumentTitle.ts
@@ -21,7 +21,7 @@ type UseDocumentTitleOptions = {
  * ```
  */
 export function useDocumentTitle(
-  title: string,
+  title: string | undefined,
   options: UseDocumentTitleOptions = {},
 ): void {
   const { preserveTitleOnUnmount = true } = options
@@ -32,7 +32,7 @@ export function useDocumentTitle(
   }, [])
 
   useIsomorphicLayoutEffect(() => {
-    window.document.title = title
+    window.document.title = title ?? defaultTitle.current ?? ''
   }, [title])
 
   useUnmount(() => {


### PR DESCRIPTION
I added a feature that reverts to the default title when the argument is set to undefined.