### PR TITLE
fix: `useEventCallback()` with optional callback

### DIFF
--- a/packages/usehooks-ts/src/useEventCallback/useEventCallback.ts
+++ b/packages/usehooks-ts/src/useEventCallback/useEventCallback.ts
@@ -22,7 +22,7 @@ export function useEventCallback<Args extends unknown[], R>(
 ): (...args: Args) => R
 export function useEventCallback<Args extends unknown[], R>(
   fn: ((...args: Args) => R) | undefined,
-): ((...args: Args) => R) | undefined
+): ((...args: Args) => R | undefined)
 export function useEventCallback<Args extends unknown[], R>(
   fn: ((...args: Args) => R) | undefined,
 ): ((...args: Args) => R) | undefined {


### PR DESCRIPTION
if the callback is undefined, the _return_ of the function can be undefined, not the function itself