### PR TITLE
Use deprecated addListener only on older browsers

### DIFF
--- a/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/usehooks-ts/src/useMediaQuery/useMediaQuery.ts
@@ -64,17 +64,17 @@ export function useMediaQuery(
     handleChange()
 
     // Use deprecated `addListener` and `removeListener` to support Safari < 14 (#135)
-    if (matchMedia.addListener) {
-      matchMedia.addListener(handleChange)
-    } else {
+    if (Object.prototype.hasOwnProperty.call(matchMedia, 'addEventListener')) {
       matchMedia.addEventListener('change', handleChange)
+    } else {
+      matchMedia.addListener(handleChange)
     }
 
     return () => {
-      if (matchMedia.removeListener) {
-        matchMedia.removeListener(handleChange)
-      } else {
+      if (Object.prototype.hasOwnProperty.call(matchMedia, 'removeEventListener')) {
         matchMedia.removeEventListener('change', handleChange)
+      } else {
+        matchMedia.removeListener(handleChange)
       }
     }
   }, [query])


### PR DESCRIPTION
Pretty much every browser still supports the deprecated methods, this pull request aims to address this issue and use old methods only for browsers not supporting the new ways 😄 

