### PR TITLE
Passing ref node to the onChange callback fn in useIntersectionObserver

### DIFF
--- a/packages/usehooks-ts/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/usehooks-ts/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -9,7 +9,7 @@ type State = {
 }
 
 /** Represents the options for configuring the Intersection Observer. */
-type UseIntersectionObserverOptions = {
+type UseIntersectionObserverOptions<T> = {
   /**
    * The element that is used as the viewport for checking visibility of the target.
    * @default null
@@ -36,7 +36,11 @@ type UseIntersectionObserverOptions = {
    * @param {IntersectionObserverEntry} entry - The intersection observer Entry.
    * @default undefined
    */
-  onChange?: (isIntersecting: boolean, entry: IntersectionObserverEntry) => void
+  onChange?: (
+    isIntersecting: boolean,
+    entry: IntersectionObserverEntry,
+    node: T | null,
+  ) => void
   /**
    * The initial state of the intersection.
    * @default false
@@ -52,12 +56,12 @@ type UseIntersectionObserverOptions = {
  * @param {boolean} isIntersecting - A boolean indicating if the element is intersecting.
  * @param {IntersectionObserverEntry | undefined} entry - The intersection observer Entry.
  */
-type IntersectionReturn = [
-  (node?: Element | null) => void,
+type IntersectionReturn<T> = [
+  (node?: T | null) => void,
   boolean,
   IntersectionObserverEntry | undefined,
 ] & {
-  ref: (node?: Element | null) => void
+  ref: (node?: T | null) => void
   isIntersecting: boolean
   entry?: IntersectionObserverEntry
 }
@@ -79,22 +83,22 @@ type IntersectionReturn = [
  * const { ref, isIntersecting, entry } = useIntersectionObserver({ threshold: 0.5 });
  * ```
  */
-export function useIntersectionObserver({
+export const useIntersectionObserver = <T extends Element>({
   threshold = 0,
   root = null,
   rootMargin = '0%',
   freezeOnceVisible = false,
   initialIsIntersecting = false,
   onChange,
-}: UseIntersectionObserverOptions = {}): IntersectionReturn {
-  const [ref, setRef] = useState<Element | null>(null)
+}: UseIntersectionObserverOptions<T> = {}): IntersectionReturn<T> => {
+  const [ref, setRef] = useState<T | null>(null)
 
   const [state, setState] = useState<State>(() => ({
     isIntersecting: initialIsIntersecting,
     entry: undefined,
   }))
 
-  const callbackRef = useRef<UseIntersectionObserverOptions['onChange']>()
+  const callbackRef = useRef<UseIntersectionObserverOptions<T>['onChange']>()
 
   callbackRef.current = onChange
 
@@ -126,7 +130,7 @@ export function useIntersectionObserver({
           setState({ isIntersecting, entry })
 
           if (callbackRef.current) {
-            callbackRef.current(isIntersecting, entry)
+            callbackRef.current(isIntersecting, entry, ref)
           }
 
           if (isIntersecting && freezeOnceVisible && unobserve) {
@@ -175,7 +179,7 @@ export function useIntersectionObserver({
     setRef,
     !!state.isIntersecting,
     state.entry,
-  ] as IntersectionReturn
+  ] as IntersectionReturn<T>
 
   // Support object destructuring, by adding the specific values.
   result.ref = result[0]

--- a/packages/usehooks-ts/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/usehooks-ts/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -34,6 +34,7 @@ type UseIntersectionObserverOptions<T> = {
    * A callback function to be invoked when the intersection state changes.
    * @param {boolean} isIntersecting - A boolean indicating if the element is intersecting.
    * @param {IntersectionObserverEntry} entry - The intersection observer Entry.
+   * @param {T | null} node - The DOM node being observed.
    * @default undefined
    */
   onChange?: (
@@ -68,6 +69,7 @@ type IntersectionReturn<T> = [
 
 /**
  * Custom hook that tracks the intersection of a DOM element with its containing element or the viewport using the [`Intersection Observer API`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+ * @template T - The type of the element's reference.
  * @param {UseIntersectionObserverOptions} options - The options for the Intersection Observer.
  * @returns {IntersectionReturn} The ref callback, a boolean indicating if the element is intersecting, and the intersection observer entry.
  * @public
@@ -83,14 +85,14 @@ type IntersectionReturn<T> = [
  * const { ref, isIntersecting, entry } = useIntersectionObserver({ threshold: 0.5 });
  * ```
  */
-export const useIntersectionObserver = <T extends Element>({
+export function useIntersectionObserver<T extends Element>({
   threshold = 0,
   root = null,
   rootMargin = '0%',
   freezeOnceVisible = false,
   initialIsIntersecting = false,
   onChange,
-}: UseIntersectionObserverOptions<T> = {}): IntersectionReturn<T> => {
+}: UseIntersectionObserverOptions<T> = {}): IntersectionReturn<T> {
   const [ref, setRef] = useState<T | null>(null)
 
   const [state, setState] = useState<State>(() => ({


### PR DESCRIPTION
**Context**
Since the breaking change in the `useIntersectionObserver` hook in [v2.13.0](https://github.com/juliencrn/usehooks-ts/releases/tag/usehooks-ts%402.13.0), we no longer have to pass a ref to the hook. Instead, it exports the callback ref for us to bind to the DOM node. However, using the callback ref loses the ref node access at the same time. For instance, the user might want to have some side effects on the ref node itself when it is intersecting. It would be helpful if the ref node were passed to the `onChange` callback so we have access to it

**Changes**
* pass ref node to the onChange callback in `useIntersectionObserver`
* add type parameter <T> so that the node passed to the callback fn will receive the correct type

**Example**
```
const { ref } = useIntersectionObserver<HTMLDivElement>({
  freezeOnceVisible: true,
  onChange: (isIntersecting, _, node) => {
    if (node !== null) {
      node.style.height = isIntersecting ? 'auto' : `100px`
    }
  },
})