### PR TITLE
feature: `useEventListener` Element to Event Map generic override & refactor: multiple overloads to single mapped type

### DIFF
--- a/packages/usehooks-ts/src/useEventListener/useEventListener.ts
+++ b/packages/usehooks-ts/src/useEventListener/useEventListener.ts
@@ -24,6 +24,35 @@ type EventMapOf<E> = {
    [K in keyof ElementToEventMap]: E extends ElementToEventMap[K][0] ? ElementToEventMap[K][1] & CustomEventsMap : never
 }[keyof ElementToEventMap]
 
+/**
+ * Custom hook that attaches event listeners to DOM elements, the window, or media query lists.
+ * @template M - The type of custom Event Map (optional generic), overrides any other element to events mapping.
+ * @template E - The type of the DOM element (default is `Window`).
+ * @template K - The type of event name, Key of an EventMap (match for DOM element).
+ * @param {K} eventName - The name of the event to listen for.
+ * @param {(event: Fallback<M, EventMapOf<E>>[K]) => void} handler - The event handler function.
+ * @param {RefObject<T>} config.ref - A reference that specifies the DOM element to attach the event listener to.
+ * @param {boolean | AddEventListenerOptions} config.options - Event listener Options.
+ * @public
+ * @see [Documentation](https://usehooks-ts.com/react-hook/use-event-listener)
+ * @example
+ * ```tsx
+ * // Example 1: Attach a window event listener
+ * useEventListener('resize', handleResize);
+ * ```
+ * @example
+ * ```tsx
+ * // Example 2: Attach a document event listener with options
+ * const ref = useRef(document);
+ * useEventListener('click', handleClick, { ref, options: { capture: true } });
+ * ```
+ * @example
+ * ```tsx
+ * // Example 3: Attach an element event listener
+ * const ref = useRef<HTMLButtonElement>(null);
+ * useEventListener('click', handleButtonClick, { ref });
+ * ```
+ */
 function useEventListener<
    /** Custom Event Map (optional generic)*/
    M extends Record<string, unknown> | undefined = undefined,

--- a/packages/usehooks-ts/src/useEventListener/useEventListener.ts
+++ b/packages/usehooks-ts/src/useEventListener/useEventListener.ts
@@ -1,121 +1,66 @@
-import { useEffect, useRef } from 'react'
+import { useIsomorphicLayoutEffect } from "../useIsomorphicLayoutEffect/useIsomorphicLayoutEffect"
+import type { RefObject } from "react"
+import { useEffect, useRef } from "react"
 
-import type { RefObject } from 'react'
+// use of CustomEventsMap at app global declaration
+/** Element as string to Matching EventMap */
+type ElementToEventMap = {
+   Window: [Window, WindowEventMap]
+   HTMLElement: [HTMLElement, HTMLElementEventMap]
+   Document: [Document, DocumentEventMap]
+   MediaQueryList: [MediaQueryList, MediaQueryListEventMap]
+   RTCDataChannel: [RTCDataChannel, RTCDataChannelEventMap]
+   RTCPeerConnection: [RTCPeerConnection, RTCPeerConnectionEventMap]
+   SpeechSynthesis: [SpeechSynthesis, SpeechSynthesisEventMap]
+   SpeechSynthesisUtterance: [SpeechSynthesisUtterance, SpeechSynthesisUtteranceEventMap]
+}
 
-import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomorphicLayoutEffect'
+/** Return `T` if `M` undefined */
+type Fallback<M, T> = M extends undefined ? T : M
 
-// MediaQueryList Event based useEventListener interface
-function useEventListener<K extends keyof MediaQueryListEventMap>(
-  eventName: K,
-  handler: (event: MediaQueryListEventMap[K]) => void,
-  element: RefObject<MediaQueryList>,
-  options?: boolean | AddEventListenerOptions,
-): void
+/** Return `EventMap` type of matching element ref (from config argument)
+ *  Intersected with `CustomEventsMap` (from global declaration) */
+type EventMapOf<E> = {
+   [K in keyof ElementToEventMap]: E extends ElementToEventMap[K][0] ? ElementToEventMap[K][1] & CustomEventsMap : never
+}[keyof ElementToEventMap]
 
-// Window Event based useEventListener interface
-function useEventListener<K extends keyof WindowEventMap>(
-  eventName: K,
-  handler: (event: WindowEventMap[K]) => void,
-  element?: undefined,
-  options?: boolean | AddEventListenerOptions,
-): void
-
-// Element Event based useEventListener interface
 function useEventListener<
-  K extends keyof HTMLElementEventMap & keyof SVGElementEventMap,
-  T extends Element = K extends keyof HTMLElementEventMap
-    ? HTMLDivElement
-    : SVGElement,
+   /** Custom Event Map (optional generic)*/
+   M extends Record<string, unknown> | undefined = undefined,
+   /** Element Type of Optional refObject (defaults to Window) */
+   E extends ElementToEventMap[keyof ElementToEventMap][0] = Window,
+   /** eventName Key of type custom EventMap if present */
+   K extends keyof Fallback<M, EventMapOf<E>> = keyof Fallback<M, EventMapOf<E>>,
 >(
-  eventName: K,
-  handler:
-    | ((event: HTMLElementEventMap[K]) => void)
-    | ((event: SVGElementEventMap[K]) => void),
-  element: RefObject<T>,
-  options?: boolean | AddEventListenerOptions,
-): void
-
-// Document Event based useEventListener interface
-function useEventListener<K extends keyof DocumentEventMap>(
-  eventName: K,
-  handler: (event: DocumentEventMap[K]) => void,
-  element: RefObject<Document>,
-  options?: boolean | AddEventListenerOptions,
-): void
-
-/**
- * Custom hook that attaches event listeners to DOM elements, the window, or media query lists.
- * @template KW - The type of event for window events.
- * @template KH - The type of event for HTML or SVG element events.
- * @template KM - The type of event for media query list events.
- * @template T - The type of the DOM element (default is `HTMLElement`).
- * @param {KW | KH | KM} eventName - The name of the event to listen for.
- * @param {(event: WindowEventMap[KW] | HTMLElementEventMap[KH] | SVGElementEventMap[KH] | MediaQueryListEventMap[KM] | Event) => void} handler - The event handler function.
- * @param {RefObject<T>} [element] - The DOM element or media query list to attach the event listener to (optional).
- * @param {boolean | AddEventListenerOptions} [options] - An options object that specifies characteristics about the event listener (optional).
- * @public
- * @see [Documentation](https://usehooks-ts.com/react-hook/use-event-listener)
- * @example
- * ```tsx
- * // Example 1: Attach a window event listener
- * useEventListener('resize', handleResize);
- * ```
- * @example
- * ```tsx
- * // Example 2: Attach a document event listener with options
- * const elementRef = useRef(document);
- * useEventListener('click', handleClick, elementRef, { capture: true });
- * ```
- * @example
- * ```tsx
- * // Example 3: Attach an element event listener
- * const buttonRef = useRef<HTMLButtonElement>(null);
- * useEventListener('click', handleButtonClick, buttonRef);
- * ```
- */
-function useEventListener<
-  KW extends keyof WindowEventMap,
-  KH extends keyof HTMLElementEventMap & keyof SVGElementEventMap,
-  KM extends keyof MediaQueryListEventMap,
-  T extends HTMLElement | SVGAElement | MediaQueryList = HTMLElement,
->(
-  eventName: KW | KH | KM,
-  handler: (
-    event:
-      | WindowEventMap[KW]
-      | HTMLElementEventMap[KH]
-      | SVGElementEventMap[KH]
-      | MediaQueryListEventMap[KM]
-      | Event,
-  ) => void,
-  element?: RefObject<T>,
-  options?: boolean | AddEventListenerOptions,
+   eventName: K & string,
+   handler: (event: Fallback<M, EventMapOf<E>>[K]) => void,
+   config: {
+      /** Litening Target (defaults to window) */
+      ref?: RefObject<E>
+      options?: boolean | AddEventListenerOptions
+   } = {},
 ) {
-  // Create a ref that stores handler
-  const savedHandler = useRef(handler)
+   // Create a ref that stores handler
+   const savedHandler = useRef(handler)
+   useIsomorphicLayoutEffect(() => {
+      savedHandler.current = handler
+   }, [handler])
 
-  useIsomorphicLayoutEffect(() => {
-    savedHandler.current = handler
-  }, [handler])
+   useEffect(() => {
+      // Define the listening target
+      const targetElement: E | Window = config.ref?.current ?? window
+      if (!targetElement) return
 
-  useEffect(() => {
-    // Define the listening target
-    const targetElement: T | Window = element?.current ?? window
+      // Create event listener that calls handler function stored in ref
+      const eventListener: EventListener = (event) => savedHandler.current(event as Parameters<typeof handler>[0])
 
-    if (!(targetElement && targetElement.addEventListener)) return
+      targetElement.addEventListener(eventName, eventListener, config.options)
 
-    // Create event listener that calls handler function stored in ref
-    const listener: typeof handler = event => {
-      savedHandler.current(event)
-    }
-
-    targetElement.addEventListener(eventName, listener, options)
-
-    // Remove event listener on cleanup
-    return () => {
-      targetElement.removeEventListener(eventName, listener, options)
-    }
-  }, [eventName, element, options])
+      // Remove event listener on cleanup
+      return () => {
+         targetElement.removeEventListener(eventName, eventListener)
+      }
+   }, [eventName, config])
 }
 
 export { useEventListener }


### PR DESCRIPTION
## Changelog

### Features
- Custom EventMap Generic (overrides any other Elements to Event Mapping declaration from hook)
```typescript
useEventListener<{ "user-storage": User }>("user-storage", (updatedUser) => console.log(updatedUser.email))
```
- Globally declared DocumentEventMap (only applied to document refs) to globally declared CustomEventsMap applied to all Elements (avoidable with EventMap generic)
```typescript
// globals.d.ts
declare global {
   interface CustomEventsMap {
      'my-custom-event': CustomEvent<{ exampleArg: string }>
   }
}
```

### Improved Readability & future refactors (by decreasing code size)
- Replaced Overloads with Generic map from Element (string) to [Element, EventMap] tuple + 2 Utility constructs
```typescript
/** Element as string to Matching EventMap */
type ElementToEventMap = {
   Window: [Window, WindowEventMap]
   HTMLElement: [HTMLElement, HTMLElementEventMap]
   Document: [Document, DocumentEventMap]
   ...
```
- Optional Arguments `element?: RefObject<T>` & `options?: boolean | AddEventListenerOptions` moved to single optional Object argument `config`

### Adding a new ref Element to Event map
Previously an overload was needed (+6 lines). Now adding a key-value pair to the ElementToEventMap which value is a tuple containing the element type and its corresponding event map type (+1 line)

## Usage Preview
```typescript
import { useEventListener } from "@/hooks"
import { useRef } from "react"

const App: React.FC = () => {
   const ref = useRef<HTMLDivElement>(null)
   useEventListener("mousedown", (value) => console.log(value.pageX), { ref })

   // Custom Event Map
   useEventListener<{ abc: { name: string; orderId: number } }>("abc", (value) => console.log(value.orderId))

   return (
      <div ref={ref} style={{ width: "200px", height: "200px", backgroundColor: "lightblue" }}>
         Click me!
      </div>
   )
}

export default App
```

- [ ] Changeset 
- [ ] Tests
- [ ] Documentation
