### PR TITLE
fix: incorrect persistence useDarkMode

### DIFF
--- a/.changeset/five-papayas-pull.md
+++ b/.changeset/five-papayas-pull.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+fix useDarkMode persistence

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.test.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.test.ts
@@ -124,4 +124,20 @@ describe('useDarkMode()', () => {
 
     expect(result.current.isDarkMode).toBe(false)
   })
+
+  it('should prioritize localStorage value over OS dark mode on page load', () => {
+    window.localStorage.setItem('custom-key', JSON.stringify(false))
+
+    mockMatchMedia(true)
+    const { result } = renderHook(() =>
+      useDarkMode({ localStorageKey: 'custom-key', initializeWithValue: true }),
+    )
+    expect(result.current.isDarkMode).toBe(false)
+
+    act(() => {
+      result.current.toggle()
+    })
+    expect(result.current.isDarkMode).toBe(true)
+    expect(window.localStorage.getItem('custom-key')).toBe(JSON.stringify(true))
+  })
 })

--- a/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
+++ b/packages/usehooks-ts/src/useDarkMode/useDarkMode.ts
@@ -1,4 +1,3 @@
-import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useLocalStorage } from '../useLocalStorage'
 import { useMediaQuery } from '../useMediaQuery'
 
@@ -61,23 +60,16 @@ export function useDarkMode(options: DarkModeOptions = {}): DarkModeReturn {
     initializeWithValue,
     defaultValue,
   })
-  const [isDarkMode, setDarkMode] = useLocalStorage<boolean>(
+  const [isDarkMode, setDarkMode] = useLocalStorage<boolean | undefined>(
     localStorageKey,
-    defaultValue ?? isDarkOS ?? false,
+    defaultValue,
     { initializeWithValue },
   )
 
-  // Update darkMode if os prefers changes
-  useIsomorphicLayoutEffect(() => {
-    if (isDarkOS !== isDarkMode) {
-      setDarkMode(isDarkOS)
-    }
-  }, [isDarkOS])
-
   return {
-    isDarkMode,
+    isDarkMode: isDarkMode ?? isDarkOS,
     toggle: () => {
-      setDarkMode(prev => !prev)
+      setDarkMode(prev => !(prev ?? isDarkOS))
     },
     enable: () => {
       setDarkMode(true)


### PR DESCRIPTION
## Fix useDarkMode persistence

This PR fixes #512. This pull request addresses the issue with the `useDarkMode` hook in what I believe is the best way: without modifying other hooks or adding overhead, unlike other PRs that attempt to fix this bug.

### Changes:

1. If there is no value in `localStorage`, it will not appear if the OS switches to dark mode.
2. The absence of a value in `localStorage` means it will correspond to the OS setting or the `defaultValue`.
3. Other hooks are used naturally without any modifications.

This fix ensures that the `useDarkMode` hook persistence correctly and efficiently.