### PR TITLE
Ensure `useDebounceCallback` flushes on dep change or unmount

### DIFF
--- a/.changeset/cold-poems-clean.md
+++ b/.changeset/cold-poems-clean.md
@@ -1,0 +1,5 @@
+---
+'usehooks-ts': patch
+---
+
+Ensure useDebounceCallback properly flushes on unmount or dependency change.

--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.test.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.test.ts
@@ -3,7 +3,13 @@ import { act, renderHook } from '@testing-library/react'
 import { useDebounceCallback } from './useDebounceCallback'
 
 describe('useDebounceCallback()', () => {
-  vitest.useFakeTimers()
+  beforeEach(() => {
+    vitest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vitest.clearAllTimers()
+  })
 
   it('should debounce the callback', () => {
     const delay = 500
@@ -106,5 +112,62 @@ describe('useDebounceCallback()', () => {
 
     // The callback should be invoked immediately after flushing
     expect(debouncedCallback).toHaveBeenCalled()
+  })
+
+  it('should flush pending invocation on unmount', () => {
+    const delay = 500
+    const debouncedCallback = vitest.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebounceCallback(debouncedCallback, delay),
+    )
+
+    act(() => {
+      result.current('argument')
+    })
+
+    vitest.advanceTimersByTime(delay / 2)
+
+    // Unmount the hook
+    unmount()
+
+    // Fast forward time
+    expect(debouncedCallback).toHaveBeenCalled()
+
+    // The callback should not be invoked after unmount
+  })
+
+  it('should flush pending invocation in case of dependency change', () => {
+    const delay = 500
+    const debouncedCallback = vitest.fn()
+    const { result, rerender } = renderHook(
+      ({ callback, wait }) => useDebounceCallback(callback, wait),
+      { initialProps: { callback: debouncedCallback, wait: delay } },
+    )
+
+    act(() => {
+      result.current('test1')
+    })
+
+    // Change the delay
+    const newDelay = 1000
+    rerender({ callback: debouncedCallback, wait: newDelay })
+
+    // The previous call should be flushed
+    expect(debouncedCallback).toHaveBeenCalled()
+    expect(debouncedCallback).toHaveBeenCalledWith('test1')
+
+    vi.clearAllMocks()
+
+    act(() => {
+      result.current('test2')
+    })
+
+    // Fast forward time
+    vitest.advanceTimersByTime(newDelay)
+
+    // The callback should be invoked for the second call
+    expect(debouncedCallback).toHaveBeenCalledTimes(1)
+
+    expect(debouncedCallback).toHaveBeenCalledWith('test2')
   })
 })

--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
@@ -80,12 +80,16 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
 
   useUnmount(() => {
     if (debouncedFunc.current) {
-      debouncedFunc.current.cancel()
+      debouncedFunc.current.flush()
+      debouncedFunc.current = undefined
     }
   })
 
   const debounced = useMemo(() => {
+    debouncedFunc.current?.flush()
+
     const debouncedFuncInstance = debounce(func, delay, options)
+    debouncedFunc.current = debouncedFuncInstance
 
     const wrappedFunc: DebouncedState<T> = (...args: Parameters<T>) => {
       return debouncedFuncInstance(...args)
@@ -104,11 +108,6 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
     }
 
     return wrappedFunc
-  }, [func, delay, options])
-
-  // Update the debounced function ref whenever func, wait, or options change
-  useEffect(() => {
-    debouncedFunc.current = debounce(func, delay, options)
   }, [func, delay, options])
 
   return debounced


### PR DESCRIPTION
I believe this is an important improvement to make sure pending debounced invocations are called right before unmounting or dependency changes to the hook.

Someone might want them to be cancelled in these cases instead, but I think the general expectation is that if you make a call to a debounced function, it will eventually be invoked.

If the needs arise, we could add a new boolean option or a union type:

```ts
type AdditionalOptions = {
  cancelOnCleanup: boolean; // or
  cleanupBehavior: 'flush' | 'cancel' | 'none';
}
```