### PR TITLE
fix: Resize Observer in Portal

### DIFF
--- a/packages/usehooks-ts/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/usehooks-ts/src/useResizeObserver/useResizeObserver.ts
@@ -101,7 +101,7 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>(
     return () => {
       observer.disconnect()
     }
-  }, [box, ref, isMounted])
+  }, [box, ref.current, isMounted])
 
   return { width, height }
 }


### PR DESCRIPTION
Fixes [issue 632](https://github.com/juliencrn/usehooks-ts/issues/632). When using the hook within a component inside an initially unmounted portal (i.e. dialog, drawer, etc.), the ref object mutates and does not update the primary effect. Changing the dependency to include the current causes the effect update properly.