### PR TITLE
fix(useScrollLock): correct scrollbarWidth calculation in widthReflow

### DIFF
--- a/packages/usehooks-ts/src/useScrollLock/useScrollLock.ts
+++ b/packages/usehooks-ts/src/useScrollLock/useScrollLock.ts
@@ -89,7 +89,7 @@ export function useScrollLock(
           parseInt(window.getComputedStyle(target.current).paddingRight, 10) ||
           0
 
-        const scrollbarWidth = offsetWidth - target.current.scrollWidth
+        const scrollbarWidth = offsetWidth - target.current.clientWidth
         target.current.style.paddingRight = `${scrollbarWidth + currentPaddingRight}px`
       }
 


### PR DESCRIPTION
Fixes incorrect scrollbar width calculation in `widthReflow` (used by `useScrollLock`).

The old implementation used `scrollWidth`, which returns the total scrollable width — even content that overflows. This made the scrollbar width calculation wrong in some cases.

Now it uses `clientWidth`, which gives the actual visible area (content + padding, excluding scrollbar), and the result is accurate.
