### PR TITLE
refactor(useUnmount): defer ref assignment to layout phase for better React lifecycle compliance

### DIFF
--- a/packages/usehooks-ts/src/useUnmount/useUnmount.ts
+++ b/packages/usehooks-ts/src/useUnmount/useUnmount.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { useIsomorphicLayoutEffect } from 'src/useIsomorphicLayoutEffect'
 
 /**
  * Custom hook that runs a cleanup function when the component is unmounted.
@@ -15,7 +16,9 @@ import { useEffect, useRef } from 'react'
 export function useUnmount(func: () => void) {
   const funcRef = useRef(func)
 
-  funcRef.current = func
+  useIsomorphicLayoutEffect(()=>{
+    funcRef.current = func
+  },[func])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
### What’s changed

This PR updates the `useUnmount` hook by moving the `funcRef.current = func` assignment out of the render phase and into a `useIsomorphicLayoutEffect`.

### Why

Assigning to refs during render is not recommended in React, especially under concurrent or strict mode. It can lead to subtle bugs or mismatches between what React thinks and what actually happens.

By moving this to the layout phase, we ensure the ref is updated safely, and it aligns better with React's lifecycle best practices.

### Notes

This change doesn’t alter the behavior of `useUnmount` — it’s a lifecycle correctness refactor only.
