### PR TITLE
fix(useDebounceValue): make delay parameter optional with default 500ms

### DIFF
--- a/packages/usehooks-ts/src/useDebounceValue/useDebounceValue.ts
+++ b/packages/usehooks-ts/src/useDebounceValue/useDebounceValue.ts
@@ -42,7 +42,7 @@ type UseDebounceValueOptions<T> = {
  */
 export function useDebounceValue<T>(
   initialValue: T | (() => T),
-  delay: number,
+  delay?: number,
   options?: UseDebounceValueOptions<T>,
 ): [T, DebouncedState<(value: T) => void>] {
   const eq = options?.equalityFn ?? ((left: T, right: T) => left === right)
@@ -53,7 +53,7 @@ export function useDebounceValue<T>(
 
   const updateDebouncedValue = useDebounceCallback(
     setDebouncedValue,
-    delay,
+    delay ?? 500,
     options,
   )
 


### PR DESCRIPTION
###  What’s fixed

This PR fixes [#694](https://github.com/juliencrn/usehooks-ts/issues/694) — the `delay` parameter in `useDebounceValue` is now optional with a default of `500ms`, aligning it with the behavior of `useDebounceCallback` and the official documentation.

###  What’s changed

- `delay` parameter is now optional 
- No longer throws a TypeScript error when the `delay` argument is omitted
- API is backward-compatible

###  Example usage

```tsx
const [debouncedValue] = useDebounceValue(input)
