### PR TITLE
feat(useCopyToClipboard): add callback support for copy operations

### DIFF
--- a/apps/www/src/components/command-copy.tsx
+++ b/apps/www/src/components/command-copy.tsx
@@ -30,11 +30,17 @@ export function CommandCopy({
   const [, copy] = useCopyToClipboard()
 
   const handleCopy = (text: string) => {
-    setCopiedStatus(true)
-    void copy(text)
-    setTimeout(() => {
-      setCopiedStatus(false)
-    }, 2000)
+    copy(text, {
+      onSuccess: () => {
+        setCopiedStatus(true)
+        setTimeout(() => {
+          setCopiedStatus(false)
+        }, 2000)
+      },
+      onError: ({ error }) => {
+        console.error('Failed to copy to clipboard:', error)
+      },
+    })
   }
   const renderedCommand =
     typeof command === 'string'

--- a/packages/usehooks-ts/src/useCopyToClipboard/useCopyToClipboard.demo.tsx
+++ b/packages/usehooks-ts/src/useCopyToClipboard/useCopyToClipboard.demo.tsx
@@ -3,7 +3,20 @@ import { useCopyToClipboard } from './useCopyToClipboard'
 export default function Component() {
   const [copiedText, copy] = useCopyToClipboard()
 
-  const handleCopy = (text: string) => () => {
+  // Using callbacks (recommended)
+  const handleCopyWithCallbacks = (text: string) => () => {
+    copy(text, {
+      onSuccess: ({ text }) => {
+        console.log('Copied!', { text })
+      },
+      onError: ({ error, text }) => {
+        console.error('Failed to copy!', { error, text })
+      },
+    })
+  }
+
+  // Using promises (backward compatible)
+  const handleCopyWithPromise = (text: string) => () => {
     copy(text)
       .then(() => {
         console.log('Copied!', { text })
@@ -16,11 +29,21 @@ export default function Component() {
   return (
     <>
       <h1>Click to copy:</h1>
-      <div style={{ display: 'flex' }}>
-        <button onClick={handleCopy('A')}>A</button>
-        <button onClick={handleCopy('B')}>B</button>
-        <button onClick={handleCopy('C')}>C</button>
+
+      <h2>Using callbacks:</h2>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button onClick={handleCopyWithCallbacks('A')}>A</button>
+        <button onClick={handleCopyWithCallbacks('B')}>B</button>
+        <button onClick={handleCopyWithCallbacks('C')}>C</button>
       </div>
+
+      <h2>Using promises (backward compatible):</h2>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button onClick={handleCopyWithPromise('X')}>X</button>
+        <button onClick={handleCopyWithPromise('Y')}>Y</button>
+        <button onClick={handleCopyWithPromise('Z')}>Z</button>
+      </div>
+
       <p>Copied value: {copiedText ?? 'Nothing is copied yet!'}</p>
     </>
   )

--- a/packages/usehooks-ts/src/useCopyToClipboard/useCopyToClipboard.test.ts
+++ b/packages/usehooks-ts/src/useCopyToClipboard/useCopyToClipboard.test.ts
@@ -38,4 +38,142 @@ describe('useCopyToClipboard()', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockData)
     expect(result.current[0]).toBe(mockData)
   })
+
+  describe('callback functionality', () => {
+    it('should call onSuccess callback when copy succeeds', async () => {
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onSuccess = vitest.fn()
+      const onError = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onSuccess, onError })
+      })
+
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+      expect(onSuccess).toHaveBeenCalledWith({ text: mockData })
+      expect(onError).not.toHaveBeenCalled()
+    })
+
+    it('should call onError callback when clipboard is not supported', async () => {
+      // @ts-ignore mock clipboard
+      global.navigator.clipboard = undefined
+
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onSuccess = vitest.fn()
+      const onError = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onSuccess, onError })
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith({
+        error: expect.any(Error),
+        text: mockData,
+      })
+      expect(onError.mock.calls[0][0].error.message).toBe(
+        'Clipboard not supported',
+      )
+      expect(onSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should call onError callback when writeText fails', async () => {
+      const mockError = new Error('Write failed')
+      const mockClipboard = {
+        writeText: vitest.fn().mockRejectedValue(mockError),
+      }
+      // @ts-ignore mock clipboard
+      global.navigator.clipboard = mockClipboard
+
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onSuccess = vitest.fn()
+      const onError = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onSuccess, onError })
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith({
+        error: mockError,
+        text: mockData,
+      })
+      expect(onSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should work without callbacks (backward compatibility)', async () => {
+      const { result } = renderHook(() => useCopyToClipboard())
+
+      let returnValue: boolean | undefined
+
+      await act(async () => {
+        returnValue = await result.current[1](mockData)
+      })
+
+      expect(returnValue).toBe(true)
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockData)
+      expect(result.current[0]).toBe(mockData)
+    })
+
+    it('should work with only onSuccess callback', async () => {
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onSuccess = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onSuccess })
+      })
+
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+      expect(onSuccess).toHaveBeenCalledWith({ text: mockData })
+    })
+
+    it('should work with only onError callback', async () => {
+      // @ts-ignore mock clipboard
+      global.navigator.clipboard = undefined
+
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onError = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onError })
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return promise that resolves alongside callbacks', async () => {
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onSuccess = vitest.fn()
+
+      let promiseResult: boolean | undefined
+
+      await act(async () => {
+        promiseResult = await result.current[1](mockData, { onSuccess })
+      })
+
+      expect(promiseResult).toBe(true)
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('should convert non-Error objects to Error in onError callback', async () => {
+      const mockClipboard = {
+        writeText: vitest.fn().mockRejectedValue('string error'),
+      }
+      // @ts-ignore mock clipboard
+      global.navigator.clipboard = mockClipboard
+
+      const { result } = renderHook(() => useCopyToClipboard())
+      const onError = vitest.fn()
+
+      await act(async () => {
+        await result.current[1](mockData, { onError })
+      })
+
+      expect(onError).toHaveBeenCalledWith({
+        error: expect.any(Error),
+        text: mockData,
+      })
+      expect(onError.mock.calls[0][0].error.message).toBe('string error')
+    })
+  })
 })


### PR DESCRIPTION
Adds optional onSuccess and onError callbacks to the copy function while maintaining full backward compatibility with the promise-based API.

### New API

```typescript
const [copiedText, copy] = useCopyToClipboard();

// Using callbacks (recommended for most use cases)
copy(text, {
  onSuccess: ({ text }) => {
    console.log('Copied!', { text });
  },
  onError: ({ error, text }) => {
    console.error('Failed to copy!', { error, text });
  }
});

// Promise-based API still works (backward compatible)
copy(text)
  .then(() => console.log('Copied!'))
  .catch(error => console.error('Failed!', error));
```

### Changes

- **Hook Implementation**: Added `CopyOptions` type with optional `onSuccess` and `onError` callbacks
- **Structured Callback Data**: 
  - `onSuccess` receives `{ text: string }`
  - `onError` receives `{ error: Error, text: string }`
- **Demo Updated**: Shows both callback and promise patterns side by side
- **Comprehensive Tests**: Added 8 new tests covering all callback scenarios
- **Real-world Usage**: Refactored `command-copy.tsx` to use callbacks for better reliability

### Benefits

- ✅ **Backward Compatible**: All existing code continues to work without changes
- ✅ **Better Ergonomics**: Cleaner syntax for common use cases
- ✅ **Improved Reliability**: Status updates only on actual success
- ✅ **Better Error Context**: Both error and text available in error callback
- ✅ **Type Safe**: Full TypeScript support with proper types

This enhancement provides a more ergonomic API for common use cases while preserving all existing functionality.