### PR TITLE
feat(useCountdown): add autoStart and onFinish options

### DIFF
--- a/.changeset/quiet-rabbits-share.md
+++ b/.changeset/quiet-rabbits-share.md
@@ -1,0 +1,5 @@
+---
+'usehooks-ts': patch
+---
+
+feat(useCountdown): add `autoStart` and `onFinish` options.

--- a/packages/usehooks-ts/src/useCountdown/useCountdown.demo.tsx
+++ b/packages/usehooks-ts/src/useCountdown/useCountdown.demo.tsx
@@ -6,18 +6,30 @@ import { useCountdown } from './useCountdown'
 
 export default function Component() {
   const [intervalValue, setIntervalValue] = useState<number>(1000)
+  const [message, setMessage] = useState('Running...')
+
   const [count, { startCountdown, stopCountdown, resetCountdown }] =
     useCountdown({
-      countStart: 60,
+      countStart: 10,
+      countStop: 0,
       intervalMs: intervalValue,
+      autoStart: true,
+      onFinish: () => setMessage('Finished!'),
     })
 
   const handleChangeIntervalValue = (event: ChangeEvent<HTMLInputElement>) => {
     setIntervalValue(Number(event.target.value))
   }
+
+  const handleReset = () => {
+    setMessage('Running...')
+    resetCountdown()
+  }
+
   return (
     <div>
       <p>Count: {count}</p>
+      <p>{message}</p>
 
       <input
         type="number"
@@ -26,7 +38,7 @@ export default function Component() {
       />
       <button onClick={startCountdown}>start</button>
       <button onClick={stopCountdown}>stop</button>
-      <button onClick={resetCountdown}>reset</button>
+      <button onClick={handleReset}>reset</button>
     </div>
   )
 }

--- a/packages/usehooks-ts/src/useCountdown/useCountdown.md
+++ b/packages/usehooks-ts/src/useCountdown/useCountdown.md
@@ -4,6 +4,11 @@ A simple countdown implementation. Support increment and decrement.
 
 NEW VERSION: A simple countdown implementation. Accepts `countStop`(new), `countStart` (was `seconds`), `intervalMs`(was `interval`) and `isIncrement` as keys of the call argument. Support increment and decrement. Will stop when at `countStop`.
 
+Also supports:
+
+- `autoStart` to start immediately on mount.
+- `onFinish` callback when the counter reaches `countStop`.
+
 Related hooks:
 
 - [`useBoolean()`](/react-hook/use-boolean)

--- a/packages/usehooks-ts/src/useCountdown/useCountdown.test.ts
+++ b/packages/usehooks-ts/src/useCountdown/useCountdown.test.ts
@@ -181,4 +181,42 @@ describe('useCountdown()', () => {
     act(result.current[1].resetCountdown)
     expect(result.current[0]).toBe(60)
   })
+
+  it('should auto start when autoStart is true', () => {
+    const { result } = renderHook(() =>
+      useCountdown({ countStart: 5, countStop: 0, intervalMs: 1000, autoStart: true }),
+    )
+
+    act(() => {
+      vitest.advanceTimersByTime(2000)
+    })
+
+    expect(result.current[0]).toBe(3)
+  })
+
+  it('should call onFinish when countdown reaches countStop', () => {
+    const onFinish = vitest.fn()
+
+    renderHook(() =>
+      useCountdown({
+        countStart: 3,
+        countStop: 0,
+        intervalMs: 1000,
+        autoStart: true,
+        onFinish,
+      }),
+    )
+
+    act(() => {
+      vitest.advanceTimersByTime(3000)
+    })
+
+    expect(onFinish).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vitest.advanceTimersByTime(3000)
+    })
+
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/usehooks-ts/src/useCountdown/useCountdown.ts
+++ b/packages/usehooks-ts/src/useCountdown/useCountdown.ts
@@ -14,6 +14,7 @@ type CountdownOptions = {
    * @default 1000
    */
   intervalMs?: number
+
   /**
    * True if the countdown is increment.
    * @default false
@@ -25,6 +26,17 @@ type CountdownOptions = {
    * @default 0
    */
   countStop?: number
+
+  /**
+   * Starts the countdown immediately when the hook mounts.
+   * @default false
+   */
+  autoStart?: boolean
+
+  /**
+   * Callback fired once the countdown reaches `countStop`.
+   */
+  onFinish?: () => void
 }
 
 /** The countdown's controllers. */
@@ -49,6 +61,8 @@ type CountdownControllers = {
  *   countStart: 10,
  *   intervalMs: 1000,
  *   isIncrement: false,
+ *   autoStart: true,
+ *   onFinish: () => console.log('Done!'),
  * });
  * ```
  */
@@ -57,13 +71,10 @@ export function useCountdown({
   countStop = 0,
   intervalMs = 1000,
   isIncrement = false,
+  autoStart = false,
+  onFinish,
 }: CountdownOptions): [number, CountdownControllers] {
-  const {
-    count,
-    increment,
-    decrement,
-    reset: resetCounter,
-  } = useCounter(countStart)
+  const { count, reset: resetCounter, setCount } = useCounter(countStart)
 
   /*
    * Note: used to control the useInterval
@@ -75,7 +86,7 @@ export function useCountdown({
     value: isCountdownRunning,
     setTrue: startCountdown,
     setFalse: stopCountdown,
-  } = useBoolean(false)
+  } = useBoolean(autoStart)
 
   // Will set running false and reset the seconds to initial value.
   const resetCountdown = useCallback(() => {
@@ -84,17 +95,26 @@ export function useCountdown({
   }, [stopCountdown, resetCounter])
 
   const countdownCallback = useCallback(() => {
-    if (count === countStop) {
-      stopCountdown()
-      return
-    }
+    setCount(previousCount => {
+      if (previousCount === countStop) {
+        stopCountdown()
+        onFinish?.()
+        return previousCount
+      }
 
-    if (isIncrement) {
-      increment()
-    } else {
-      decrement()
-    }
-  }, [count, countStop, decrement, increment, isIncrement, stopCountdown])
+      const nextCount = isIncrement ? previousCount + 1 : previousCount - 1
+      const willReachStop = isIncrement
+        ? nextCount >= countStop
+        : nextCount <= countStop
+
+      if (willReachStop) {
+        stopCountdown()
+        onFinish?.()
+      }
+
+      return nextCount
+    })
+  }, [countStop, isIncrement, onFinish, setCount, stopCountdown])
 
   useInterval(countdownCallback, isCountdownRunning ? intervalMs : null)
 


### PR DESCRIPTION
## Description
Adds two new options to `useCountdown` to simplify consumption and avoid extra `useEffect` usage in user-land:
- `autoStart?: boolean` to start the countdown on mount
- `onFinish?: () => void` callback fired when `countStop` is reached

## Type of change
- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🧪 Tests
- [x] 📚 Documentation

## What changed
- Updated `useCountdown` options and implementation
- Added tests for `autoStart` and `onFinish`
- Updated hook docs/demo
- Added changeset for package version bump

## Testing
- [x] `pnpm -C packages/usehooks-ts test useCountdown`
- [ ] `pnpm -C packages/usehooks-ts lint` *(fails in this environment due to missing `eslint-plugin-import`)*