### PR TITLE
feature: Add `integrity` & `crossOrigin` options to `useScript`

### DIFF
--- a/packages/usehooks-ts/src/useScript/useScript.test.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.test.ts
@@ -4,7 +4,7 @@ import { useScript } from './useScript'
 
 describe('useScript', () => {
   it('should handle script loading error', () => {
-    const src = 'https://example.com/myscript.js'
+    const src = 'https://example.com/test-error.js'
 
     const { result } = renderHook(() => useScript(src))
 
@@ -21,7 +21,7 @@ describe('useScript', () => {
   })
 
   it('should remove script on unmount', () => {
-    const src = '/'
+    const src = 'https://example.com/test-remove-on-unmount.js'
 
     // First load the script
     const { result } = renderHook(() =>
@@ -63,7 +63,7 @@ describe('useScript', () => {
   })
 
   it('should have a `id` attribute when given', () => {
-    const src = '/'
+    const src = 'https://example.com/test-id.js'
     const id = 'my-script'
 
     const { result } = renderHook(() => useScript(src, { id }))
@@ -81,11 +81,11 @@ describe('useScript', () => {
     expect(document.querySelector(`script[src="${src}"]`)?.id).toBe(id)
   })
 
-  it('should set `integrity` when given', () => {
-    const src = 'https://example.com/unique-script-integrity.js'
-    const integrity = 'integrity-hash'
+  it('should have a `crossOrigin` attribute when given', () => {
+    const src = 'https://example.com/test-crossorigin.js'
+    const crossOrigin = 'use-credentials'
 
-    const { result } = renderHook(() => useScript(src, { integrity }))
+    const { result } = renderHook(() => useScript(src, { crossOrigin }))
 
     act(() => {
       document
@@ -95,10 +95,55 @@ describe('useScript', () => {
 
     expect(result.current).toBe('ready')
 
-    // Assert the attribute set by setAttribute (impl uses setAttribute for integrity)
-    const script = document.querySelector(`script[src="${src}"]`)
+    const script = document.querySelector<HTMLScriptElement>(
+      `script[src="${src}"]`,
+    )!
     expect(script).not.toBeNull()
-    expect((script as HTMLScriptElement)?.integrity).toBe(integrity)
-    expect((script as HTMLScriptElement)?.crossOrigin).toBe('anonymous')
+    expect(script.crossOrigin).toBe(crossOrigin)
+  })
+
+  it.each([
+    {
+      scenario:
+        "defaults crossOrigin to 'anonymous' when integrity is set and crossOrigin is not supplied",
+      integrity: 'integrity-hash-1',
+      crossOrigin: undefined,
+      expectedCrossOrigin: 'anonymous',
+    },
+    {
+      scenario:
+        "uses supplied crossOrigin 'anonymous' when both integrity and crossOrigin are set",
+      integrity: 'integrity-hash-2',
+      crossOrigin: 'anonymous',
+      expectedCrossOrigin: 'anonymous',
+    },
+    {
+      scenario:
+        "uses supplied crossOrigin 'use-credentials' when both integrity and crossOrigin are set",
+      integrity: 'integrity-hash-3',
+      crossOrigin: 'use-credentials',
+      expectedCrossOrigin: 'use-credentials',
+    },
+  ])('$scenario', ({ integrity, crossOrigin, expectedCrossOrigin }) => {
+    const src = `https://example.com/file-${integrity}.js`
+
+    const { result } = renderHook(() =>
+      useScript(src, { integrity, crossOrigin }),
+    )
+
+    act(() => {
+      document
+        .querySelector(`script[src="${src}"]`)
+        ?.dispatchEvent(new Event('load'))
+    })
+
+    expect(result.current).toBe('ready')
+
+    const script = document.querySelector<HTMLScriptElement>(
+      `script[src="${src}"]`,
+    )!
+    expect(script).not.toBeNull()
+    expect(script.integrity).toBe(integrity)
+    expect(script.crossOrigin).toBe(expectedCrossOrigin)
   })
 })

--- a/packages/usehooks-ts/src/useScript/useScript.test.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.test.ts
@@ -97,9 +97,9 @@ describe('useScript', () => {
 
     const script = document.querySelector<HTMLScriptElement>(
       `script[src="${src}"]`,
-    )!
+    )
     expect(script).not.toBeNull()
-    expect(script.crossOrigin).toBe(crossOrigin)
+    expect(script?.crossOrigin).toBe(crossOrigin)
   })
 
   it.each([
@@ -141,9 +141,9 @@ describe('useScript', () => {
 
     const script = document.querySelector<HTMLScriptElement>(
       `script[src="${src}"]`,
-    )!
+    )
     expect(script).not.toBeNull()
-    expect(script.integrity).toBe(integrity)
-    expect(script.crossOrigin).toBe(expectedCrossOrigin)
+    expect(script?.integrity).toBe(integrity)
+    expect(script?.crossOrigin).toBe(expectedCrossOrigin)
   })
 })

--- a/packages/usehooks-ts/src/useScript/useScript.test.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.test.ts
@@ -80,4 +80,25 @@ describe('useScript', () => {
     expect(document.querySelector(`script[id="${id}"]`)).not.toBeNull()
     expect(document.querySelector(`script[src="${src}"]`)?.id).toBe(id)
   })
+
+  it('should set `integrity` when given', () => {
+    const src = 'https://example.com/unique-script-integrity.js'
+    const integrity = 'integrity-hash'
+
+    const { result } = renderHook(() => useScript(src, { integrity }))
+
+    act(() => {
+      document
+        .querySelector(`script[src="${src}"]`)
+        ?.dispatchEvent(new Event('load'))
+    })
+
+    expect(result.current).toBe('ready')
+
+    // Assert the attribute set by setAttribute (impl uses setAttribute for integrity)
+    const script = document.querySelector(`script[src="${src}"]`)
+    expect(script).not.toBeNull()
+    expect((script as HTMLScriptElement)?.integrity).toBe(integrity)
+    expect((script as HTMLScriptElement)?.crossOrigin).toBe('anonymous')
+  })
 })

--- a/packages/usehooks-ts/src/useScript/useScript.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.ts
@@ -103,7 +103,7 @@ export function useScript(
       if (options?.integrity) {
         scriptNode.integrity = options.integrity
       }
-      if (options?.crossOrigin || options?.integrity) {
+      if (!!options?.crossOrigin || !!options?.integrity) {
         scriptNode.crossOrigin = options?.crossOrigin ?? 'anonymous'
       }
       scriptNode.setAttribute('data-status', 'loading')
@@ -150,7 +150,14 @@ export function useScript(
         cachedScriptStatuses.delete(src)
       }
     }
-  }, [src, options?.shouldPreventLoad, options?.removeOnUnmount, options?.id])
+  }, [
+    src,
+    options?.shouldPreventLoad,
+    options?.removeOnUnmount,
+    options?.id,
+    options?.integrity,
+    options?.crossOrigin,
+  ])
 
   return status
 }

--- a/packages/usehooks-ts/src/useScript/useScript.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.ts
@@ -11,8 +11,14 @@ type UseScriptOptions = {
   removeOnUnmount?: boolean
   /** Script's `id` (optional). */
   id?: string
-  /** Script's `integrity` property (optional). */
+  /**
+   * Script's [`integrity` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/integrity) (optional).
+   *
+   * _Note:_ As a side effect of this being set the `crossOrigin` property will be set to `'anonymous' unless explicitly configured differently.
+   */
   integrity?: string
+  /** Script's [`crossOrigin` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/crossOrigin) (optional). */
+  crossOrigin?: string
 }
 
 // Cached script statuses
@@ -95,8 +101,10 @@ export function useScript(
         scriptNode.id = options.id
       }
       if (options?.integrity) {
-        scriptNode.crossOrigin = 'anonymous'
         scriptNode.integrity = options.integrity
+      }
+      if (options?.crossOrigin || options?.integrity) {
+        scriptNode.crossOrigin = options?.crossOrigin ?? 'anonymous'
       }
       scriptNode.setAttribute('data-status', 'loading')
       document.body.appendChild(scriptNode)

--- a/packages/usehooks-ts/src/useScript/useScript.ts
+++ b/packages/usehooks-ts/src/useScript/useScript.ts
@@ -11,6 +11,8 @@ type UseScriptOptions = {
   removeOnUnmount?: boolean
   /** Script's `id` (optional). */
   id?: string
+  /** Script's `integrity` property (optional). */
+  integrity?: string
 }
 
 // Cached script statuses
@@ -91,6 +93,10 @@ export function useScript(
       scriptNode.async = true
       if (options?.id) {
         scriptNode.id = options.id
+      }
+      if (options?.integrity) {
+        scriptNode.crossOrigin = 'anonymous'
+        scriptNode.integrity = options.integrity
       }
       scriptNode.setAttribute('data-status', 'loading')
       document.body.appendChild(scriptNode)


### PR DESCRIPTION
### What

Add new options to allow the integrity of a script loaded via `useScript` to be validated using Subresource Integrity (SRI).

Two new properties:
- `integrity` -  allows a sha to be set for the external resource ([further reading](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/integrity))
- `crossOrigin` - allows the setting of the `crossorigin` attribute, if omitted and `integrity` is set this is automatically set to `anonymous` ([further reading](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/crossOrigin))

### Why

I encountered this hook and wanted to use it but had the lack of this feature prevented me from doing so in the context.

### Demo

https://codesandbox.io/p/sandbox/rdnw2y

### Misc

- I changed the `src` of each test case as the tests were colliding. This is because the `useScript` hook has a module scoped cache keyed by `src`
- Linting passed, but I had to manually install `eslint-plugin-import` to get the linting to work at all, I've avoided including that as I wasn't sure why this was the case. Also the linter seemed to flag several issues in other hooks which I ignored