### PR TITLE
inflection fix in useCounter.ts

### DIFF
--- a/packages/usehooks-ts/src/useCounter/useCounter.ts
+++ b/packages/usehooks-ts/src/useCounter/useCounter.ts
@@ -17,7 +17,7 @@ type UseCounterReturn = {
 }
 
 /**
- * Custom hook that manages a counter with increment, decrement, reset, and setCount functionalities.
+ * Custom hook that manages a counter with increment, decrement, reset, and setCount functionality.
  * @param {number} [initialValue] - The initial value for the counter.
  * @returns {UseCounterReturn} An object containing the current count and functions to interact with the counter.
  * @public


### PR DESCRIPTION
"functionality" is an abstract noun, and therefore normally non-count.  Coercing it into a count noun makes it sound a little off.

If a count noun is preferred, "functions" might be the best option.

(I assume the README files with the same content are automatically derived from this file.)