### PR TITLE
fix: cancel correct debounced instance on unmount in useDebounceCallback

### DIFF
--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.test.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.test.ts
@@ -85,6 +85,30 @@ describe('useDebounceCallback()', () => {
     expect(debouncedCallback).not.toHaveBeenCalled()
   })
 
+  it('should cancel the debounced callback on unmount', () => {
+    const delay = 500
+    const debouncedCallback = vitest.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebounceCallback(debouncedCallback, delay),
+    )
+
+    act(() => {
+      result.current('argument')
+    })
+
+    // The callback should not be invoked immediately
+    expect(debouncedCallback).not.toHaveBeenCalled()
+
+    // Unmount the component
+    unmount()
+
+    // Fast forward time past the debounce delay
+    vitest.advanceTimersByTime(delay + 100)
+
+    // The callback should not be invoked after unmount
+    expect(debouncedCallback).not.toHaveBeenCalled()
+  })
+
   it('should flush the debounced callback', () => {
     const delay = 500
     const debouncedCallback = vitest.fn()

--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 
 import debounce from 'lodash.debounce'
 
@@ -87,6 +87,8 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
   const debounced = useMemo(() => {
     const debouncedFuncInstance = debounce(func, delay, options)
 
+    debouncedFunc.current = debouncedFuncInstance
+
     const wrappedFunc: DebouncedState<T> = (...args: Parameters<T>) => {
       return debouncedFuncInstance(...args)
     }
@@ -104,11 +106,6 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
     }
 
     return wrappedFunc
-  }, [func, delay, options])
-
-  // Update the debounced function ref whenever func, wait, or options change
-  useEffect(() => {
-    debouncedFunc.current = debounce(func, delay, options)
   }, [func, delay, options])
 
   return debounced


### PR DESCRIPTION
## Summary

The `useUnmount` cleanup in `useDebounceCallback` was cancelling a separate debounced instance (created in `useEffect`) instead of the actual instance used by callers (created in `useMemo`). This meant pending debounced calls were never cancelled on unmount.

## Changes

- Store the `debouncedFuncInstance` from `useMemo` in the ref directly, so `useUnmount` cancels the correct instance
- Remove the redundant `useEffect` that created a separate unused debounced instance
- Add unit test verifying pending callbacks are cancelled on unmount
