### PR TITLE
fix(useOnClickOutside): make eventListenerOptions optional to prevent unnecessary re-subscriptions

### DIFF
--- a/.changeset/fix-useoncickoutside-options.md
+++ b/.changeset/fix-useoncickoutside-options.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+fix(useOnClickOutside): change `eventListenerOptions` from `AddEventListenerOptions = {}` to `boolean | AddEventListenerOptions | undefined`. The previous default of `{}` created a new object reference on every render, causing `useEventListener`'s effect to re-run and re-subscribe the listener unnecessarily on each render.

--- a/.changeset/tame-hooks-optional-options.md
+++ b/.changeset/tame-hooks-optional-options.md
@@ -1,0 +1,7 @@
+---
+"usehooks-ts": patch
+---
+
+fix(useOnClickOutside): make `eventListenerOptions` optional to prevent unnecessary re-subscriptions.
+
+Previously defaulting to `{}` caused a new object reference on every render, triggering `useEffect` to tear down and re-attach the event listener each time even when nothing changed.

--- a/packages/usehooks-ts/src/useOnClickOutside/useOnClickOutside.ts
+++ b/packages/usehooks-ts/src/useOnClickOutside/useOnClickOutside.ts
@@ -17,7 +17,7 @@ type EventType =
  * @param {RefObject<T> | RefObject<T>[]} ref - The React ref object(s) representing the element(s) to watch for outside clicks.
  * @param {(event: MouseEvent | TouchEvent | FocusEvent) => void} handler - The callback function to be executed when a click outside the element occurs.
  * @param {EventType} [eventType] - The mouse event type to listen for (optional, default is 'mousedown').
- * @param {?AddEventListenerOptions} [eventListenerOptions] - The options object to be passed to the `addEventListener` method (optional).
+ * @param {boolean | AddEventListenerOptions} [eventListenerOptions] - The options to be passed to the `addEventListener` method (optional). Avoid passing an inline object literal here, as a new object reference on every render will cause the listener to be re-registered unnecessarily.
  * @returns {void}
  * @public
  * @see [Documentation](https://usehooks-ts.com/react-hook/use-on-click-outside)
@@ -33,7 +33,7 @@ export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   ref: RefObject<T> | RefObject<T>[],
   handler: (event: MouseEvent | TouchEvent | FocusEvent) => void,
   eventType: EventType = 'mousedown',
-  eventListenerOptions: AddEventListenerOptions = {},
+  eventListenerOptions?: boolean | AddEventListenerOptions,
 ): void {
   useEventListener(
     eventType,


### PR DESCRIPTION
## Summary

Fixes #693

The fourth parameter `eventListenerOptions` previously defaulted to `{}`. Because JavaScript creates a **new object reference** on every call, the `useEffect` inside `useEventListener` (which lists `options` as a dependency) would detect a change on every render and tear down/re-attach the listener each time — even when nothing meaningful changed.

## Changes

- Changed `eventListenerOptions: AddEventListenerOptions = {}` → `eventListenerOptions?: boolean | AddEventListenerOptions`
- Type broadened from `AddEventListenerOptions` to `boolean | AddEventListenerOptions`, matching the signature of the underlying `useEventListener` hook (which already accepts `options?: boolean | AddEventListenerOptions`)
- Updated JSDoc to reflect the new optional type and note the inline-object caveat

## Before / After

```ts
// Before — re-registers the listener on every render
useOnClickOutside(ref, handler)
// ↑ eventListenerOptions silently defaults to a new {} each render

// After — no options passed → undefined → effect deps stay stable
useOnClickOutside(ref, handler)

// Explicit options still work exactly as before
useOnClickOutside(ref, handler, 'mousedown', { capture: true })
```

## Backwards compatibility

Callers that omit the fourth argument are unaffected (behaviour is identical; they just stop triggering spurious re-subscriptions). Callers that explicitly pass `{ capture: true }` or similar should already be storing the options object outside the render function to avoid this class of bug; no API change is needed on their end.