### PR TITLE
fix(useDebounceCallback): stabilize options object to prevent debounce reset

### DIFF
--- a/.changeset/fix-debounce-callback-options.md
+++ b/.changeset/fix-debounce-callback-options.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+fix(useDebounceCallback): stabilize options object to prevent debounce reset

--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
@@ -104,12 +104,14 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
     }
 
     return wrappedFunc
-  }, [func, delay, options])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [func, delay, options?.leading, options?.trailing, options?.maxWait])
 
   // Update the debounced function ref whenever func, wait, or options change
   useEffect(() => {
     debouncedFunc.current = debounce(func, delay, options)
-  }, [func, delay, options])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [func, delay, options?.leading, options?.trailing, options?.maxWait])
 
   return debounced
 }


### PR DESCRIPTION
Fixes #703

## Problem

`useDebounceCallback(callback, 500, { leading: true })` never debounces because the inline options literal `{ leading: true }` creates a new object every render. The hook uses reference equality in `useMemo`/`useEffect` dependencies, so every re-render recreates the debounced function and resets the timer.

## Root Cause

```ts
// Creates new reference every render → debounce resets every time
useMemo(() => debounce(func, delay, options), [func, delay, options])
```

## Fix

Destructure options into primitive values (`leading`, `trailing`, `maxWait`) and use them directly in dependency arrays. This way the hook only recalculates when option values actually change, not when a new object reference is passed.