### PR TITLE
fix(useUnmount): avoid writing to ref during render

### DIFF
--- a/.changeset/fix-useUnmount-ref-render.md
+++ b/.changeset/fix-useUnmount-ref-render.md
@@ -1,0 +1,5 @@
+---
+"usehooks-ts": patch
+---
+
+fix(useUnmount): avoid writing to ref during render

--- a/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/usehooks-ts/src/useDebounceCallback/useDebounceCallback.ts
@@ -104,12 +104,14 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
     }
 
     return wrappedFunc
-  }, [func, delay, options])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [func, delay, options?.leading, options?.trailing, options?.maxWait])
 
   // Update the debounced function ref whenever func, wait, or options change
   useEffect(() => {
     debouncedFunc.current = debounce(func, delay, options)
-  }, [func, delay, options])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [func, delay, options?.leading, options?.trailing, options?.maxWait])
 
   return debounced
 }

--- a/packages/usehooks-ts/src/useUnmount/useUnmount.ts
+++ b/packages/usehooks-ts/src/useUnmount/useUnmount.ts
@@ -15,7 +15,9 @@ import { useEffect, useRef } from 'react'
 export function useUnmount(func: () => void) {
   const funcRef = useRef(func)
 
-  funcRef.current = func
+  useEffect(() => {
+    funcRef.current = func
+  }, [func])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
Fixes #687

## Problem

`funcRef.current = func` runs during render, which violates React's rules of refs. Per the React docs: "Do not write or read ref.current during rendering, except for initialization." React may discard a render before committing, leaving a stale ref value for the actual cleanup effect.

## Fix

Move the ref assignment into a `useEffect` that only runs after the render is committed. The latest function reference is safely stored before the unmount cleanup executes.